### PR TITLE
Require authentication for VNC/noVNC in Dockerfile.vnc

### DIFF
--- a/Dockerfile.vnc
+++ b/Dockerfile.vnc
@@ -20,6 +20,12 @@ set -euo pipefail
 export DISPLAY=:1
 export QT_X11_NO_MITSHM=1
 
+: "${VNC_PASSWORD:?VNC_PASSWORD environment variable must be set}"
+
+VNC_PASSWD_FILE="/tmp/x11vnc.pass"
+x11vnc -storepasswd "${VNC_PASSWORD}" "${VNC_PASSWD_FILE}" >/dev/null
+chmod 600 "${VNC_PASSWD_FILE}"
+
 # Start virtual X server
 Xvfb :1 -screen 0 1280x720x24 -nolisten tcp &
 
@@ -35,7 +41,7 @@ done
 openbox &
 
 # VNC server
-x11vnc -display :1 -forever -shared -nopw -rfbport 5900 &
+x11vnc -display :1 -forever -shared -rfbauth "${VNC_PASSWD_FILE}" -rfbport 5900 &
 
 # noVNC web bridge on port 1995
 websockify --web=/usr/share/novnc/ 1995 localhost:5900 &


### PR DESCRIPTION
### Motivation
- The VNC/noVNC startup in `Dockerfile.vnc` launched `x11vnc` with `-nopw` and exposed the noVNC bridge, enabling unauthenticated remote GUI access which must be mitigated.

### Description
- Require the `VNC_PASSWORD` environment variable at container startup using `: "${VNC_PASSWORD:?VNC_PASSWORD environment variable must be set}"` to ensure a password is supplied.
- Create a temporary x11vnc password file at `/tmp/x11vnc.pass` with `x11vnc -storepasswd` and set restrictive permissions via `chmod 600` to secure credentials on disk.
- Replace the insecure `-nopw` flag with `-rfbauth "${VNC_PASSWD_FILE}"` when starting `x11vnc`, while preserving the existing `websockify` noVNC bridge and exposed port behavior.
- Keep the rest of the startup flow unchanged so the container still launches the virtual X server, window manager, and `pygpt` as before.

### Testing
- Ran `rg -n "nopw|rfbauth|VNC_PASSWORD|storepasswd" Dockerfile.vnc` to confirm the insecure flag was removed and authentication hooks were added, which succeeded.
- Committed the change via `git commit` and verified the commit with `git show --stat --oneline HEAD`, which succeeded.
- Inspected the updated script with `sed`/`nl` to validate the inserted lines and `x11vnc` invocation, which succeeded.
- No container build/run tests were executed in this patch; runtime validation (building and running the image) is recommended before deploying to production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69b23f0795f0832f8f162aad48c7d784)