### PR TITLE
Sweep and classify 6.18.2 references; promote 7.0 as active line

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,9 +11,10 @@ the platform and how to operate core services.
 - [Honeycomb storage operations](honeycomb-storage.md)
 - [API reference](api-reference.md)
 - [Governance & resilience](governance.md)
-- [Linux 6.18.2 upgrade runbook](kernel-6.18.2-runbook.md)
-- [Kernel upgrade Phase 2 log](kernel-upgrade-phase2.md)
+- [Linux 6.18.2 migration note (legacy archive)](kernel-6.18.2-runbook.md)
+- [Kernel upgrade Phase 2 runbook (7.0 active line)](kernel-upgrade-phase2.md)
 - [Phase 9 rollback hooks report](phase-9-rollback.md)
+- [6.18.2 reference classification](version-reference-classification.md)
 
 ## CLI quick reference
 

--- a/docs/version-reference-classification.md
+++ b/docs/version-reference-classification.md
@@ -1,0 +1,34 @@
+# 6.18.2 Reference Classification Sweep (7.0 Active Line)
+
+**Date:** 2026-04-10  
+**Outcome:** `7.0` is the current active line across runbooks and platform guidance.  
+**Policy:** `6.18.2` references are retained only where they represent legacy history, compatibility tests, or immutable artifacts.
+
+## Classification buckets
+
+### 1) Active docs and index pages (updated/relabelled)
+- `docs/index.md` now labels `kernel-6.18.2-runbook.md` as a **legacy archive** and points readers to the 7.0 active-line runbook naming.
+
+### 2) Historical archive docs (kept as legacy context)
+- `docs/kernel-6.18.2-runbook.md` remains a historical note by design.
+- `docs/releases/2025-10-31-changeover.md` keeps `6.18.2-hueyos-v1` mentions only to document the governance transition to `7.0`.
+
+### 3) Active platform guidance (already 7.0; no baseline rollback)
+- `src/huey/memory/MD/HARDWARE.md` already states `7.0` kernel family as current and marks `6.18.2` migration as historical.
+
+### 4) Planning/prompts (updated to 7.0 current line)
+- Updated kernel examples/series in:
+  - `src/huey/prompts/master-plan-v2-final.json`
+  - `src/huey/prompts/master-plan-v3.json`
+  - `src/huey/prompts/master-plan-v5.json`
+- Added explicit legacy-context notes so `6.18.2` is not interpreted as current target guidance.
+
+### 5) Tests and compatibility fixtures (intentionally retained)
+- `tests/test_system_checks_module.py` keeps `6.18.2-*` release strings to verify legacy detection and warning paths.
+
+### 6) Immutable/generated package metadata and unrelated hash collisions (no action)
+- `platform/packaging/.../Packages` and `archives/releases/checksums/sha256sum.txt` hits are checksum/hash content, not version policy statements.
+
+## Current policy summary
+- **Current line:** `7.0.x` (core/pulse stable tracks; `7.0.0-rc7` lab gateway only).
+- **Legacy line:** `6.18.2-*` references are archival or test-fixture context only.

--- a/src/huey/prompts/master-plan-v2-final.json
+++ b/src/huey/prompts/master-plan-v2-final.json
@@ -46,8 +46,15 @@
       "purpose": "One-shot tasks, answering, decision assistance"
     },
     "bifurcation": {
-      "types": ["exact", "augmented"],
-      "triggers": ["necessity", "space", "task isolation"],
+      "types": [
+        "exact",
+        "augmented"
+      ],
+      "triggers": [
+        "necessity",
+        "space",
+        "task isolation"
+      ],
       "tracked_by": "versioning and suffix naming"
     },
     "presidency": {
@@ -81,14 +88,24 @@
   },
   "os_stack": {
     "base": "Debian 13 (Trixie preferred, Forky for testing)",
-    "kernels": ["6.18.2-hueyos-v1", "6.18.2+hueyos-amd64"],
+    "kernels": [
+      "7.0.0-hueyos-core",
+      "7.0.0-hueyos-pulse",
+      "7.0.0-rc7-hueyos-lab"
+    ],
     "orchestrator": "PyGPT-net",
     "llm_server": "Ollama",
-    "models": ["Mistral 7B-KM", "LLaMA 3.1", "DeepSeek-R1"],
+    "models": [
+      "Mistral 7B-KM",
+      "LLaMA 3.1",
+      "DeepSeek-R1"
+    ],
     "runtime": "Python 3.13.x",
     "desktop": "GNOME for comfort, MATE for performance",
     "offline_first": true,
-    "network": "Wi-Fi fallback, Ethernet bonded preferred"
+    "network": "Wi-Fi fallback, Ethernet bonded preferred",
+    "kernel_standard_series": "7.0.x",
+    "legacy_kernel_context": "6.18.2-hueyos-v1 is retained only as historical archive context."
   },
   "intent_interface": {
     "remote": {

--- a/src/huey/prompts/master-plan-v3.json
+++ b/src/huey/prompts/master-plan-v3.json
@@ -93,14 +93,18 @@
     },
     "kernels": {
       "examples": [
-        "6.18.2-hueyos-v1",
-        "6.18.2+hueyos-amd64"
+        "7.0.0-hueyos-core",
+        "7.0.0-hueyos-pulse",
+        "7.0.0-rc7-hueyos-lab"
       ],
-      "project_standard_series": "6.18.x",
+      "project_standard_series": "7.0.x",
       "tuning_goals": [
         "Strip heavy debug/tracing for performance.",
         "Integrate required drivers directly into the kernel where practical.",
         "Use ZSTD compression for faster decompression at boot."
+      ],
+      "legacy_context_notes": [
+        "6.18.2-hueyos-v1 remains historical context only for archive analysis."
       ]
     },
     "runtime": {

--- a/src/huey/prompts/master-plan-v5.json
+++ b/src/huey/prompts/master-plan-v5.json
@@ -109,14 +109,18 @@
     },
     "kernels": {
       "examples": [
-        "6.18.2-hueyos-v1",
-        "6.18.2+hueyos-amd64"
+        "7.0.0-hueyos-core",
+        "7.0.0-hueyos-pulse",
+        "7.0.0-rc7-hueyos-lab"
       ],
-      "project_standard_series": "6.18.x",
+      "project_standard_series": "7.0.x",
       "tuning_goals": [
         "Strip heavy debug/tracing for performance.",
         "Integrate required drivers directly into the kernel where practical.",
         "Use ZSTD compression for faster decompression at boot."
+      ],
+      "legacy_context_notes": [
+        "6.18.2-hueyos-v1 remains historical context only for archive analysis."
       ]
     },
     "runtime": {


### PR DESCRIPTION
### Motivation
- Remove ambiguity by clearly classifying remaining `6.18.2` mentions so repository guidance treats `7.0` as the current active kernel line. 
- Preserve historical artifacts and test fixtures that rely on `6.18.2` while preventing accidental use as active guidance.

### Description
- Relabeled the docs index entry so `docs/index.md` points to `kernel-6.18.2-runbook.md` as a legacy archive and promotes the 7.0 Phase 2 runbook as active guidance. 
- Added a new classification report at `docs/version-reference-classification.md` that documents the sweep results and policy for `6.18.2` references. 
- Updated prompt JSON files (`src/huey/prompts/master-plan-v2-final.json`, `src/huey/prompts/master-plan-v3.json`, `src/huey/prompts/master-plan-v5.json`) to use `7.0` kernel examples/series and to include explicit legacy-context notes about `6.18.2`. 
- Intentionally left `6.18.2` occurrences in `tests` (compatibility fixtures) and immutable packaging/checksum files untouched and classified as legacy or immutable content. 

### Testing
- Validated JSON syntax with `python -m json.tool` for `src/huey/prompts/master-plan-v2-final.json`, `src/huey/prompts/master-plan-v3.json`, and `src/huey/prompts/master-plan-v5.json`, which succeeded. 
- Ran `pytest -q tests/test_system_checks_module.py` and received `19 passed` indicating no regressions in the system-check tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d989798374832fba9ba405787aba0b)