### PR TITLE
Enforce GUI license acceptance and add hueyos compatibility shims

### DIFF
--- a/apps/huey_gui/main_ui.py
+++ b/apps/huey_gui/main_ui.py
@@ -2,14 +2,32 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 import threading
 import tkinter as tk
+from pathlib import Path
 from tkinter import filedialog, messagebox, simpledialog
+
+from hueyos.install_gui import validate_license_acceptance
+from hueyos.license_gui import accept_license
 
 
 def show_license_gui():
-    messagebox.showinfo("License", "License details")
+    body = "License details unavailable."
+    if LICENSE_FILE.exists():
+        body = LICENSE_FILE.read_text(encoding="utf-8", errors="replace")
+    messagebox.showinfo("License Agreement", body)
+
+
+LICENSE_FILE = Path(__file__).resolve().parents[2] / "LICENSE"
+GUI_CONFIG_PATH = Path.home() / ".hueyos" / "gui_config.json"
+
+
+def _license_hash() -> str:
+    if not LICENSE_FILE.exists():
+        return "unknown"
+    return hashlib.sha256(LICENSE_FILE.read_bytes()).hexdigest()
 
 
 def preload_all():
@@ -29,6 +47,17 @@ def run_ai_tools():
 
 
 class MainUI:
+    def __init__(self):
+        self.ensure_license_accepted()
+
+    def ensure_license_accepted(self):
+        accepted = messagebox.askyesno(
+            "License Agreement",
+            "You must accept the license agreement before using the GUI.\n\nOpen license now?",
+        )
+        validate_license_acceptance(accepted)
+        accept_license(GUI_CONFIG_PATH, _license_hash())
+
     def check_license(self):
         show_license_gui()
 

--- a/src/hueyos/__init__.py
+++ b/src/hueyos/__init__.py
@@ -1,0 +1,16 @@
+"""Compatibility namespace exposing :mod:`huey` as :mod:`hueyos`."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+_base = importlib.import_module("huey")
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_base, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(dir(_base)))

--- a/src/hueyos/install_gui.py
+++ b/src/hueyos/install_gui.py
@@ -1,0 +1,9 @@
+"""Installer helpers for GUI flows."""
+
+
+def validate_license_acceptance(accepted: bool) -> None:
+    if not accepted:
+        raise PermissionError("License agreement must be accepted before continuing.")
+
+
+__all__ = ["validate_license_acceptance"]

--- a/src/hueyos/license_gui.py
+++ b/src/hueyos/license_gui.py
@@ -1,0 +1,29 @@
+"""License acceptance helpers for GUI entrypoints."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _load_config(config_path: Path) -> dict[str, Any]:
+    if not config_path.exists():
+        return {}
+    with config_path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def accept_license(config_path: str | Path, license_hash: str) -> None:
+    path = Path(config_path)
+    config = _load_config(path)
+    config["license.accepted"] = True
+    config["license.accepted_at"] = datetime.now(timezone.utc).isoformat()
+    config["license.hash"] = license_hash
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(config, handle, indent=2, sort_keys=True)
+
+
+__all__ = ["accept_license"]


### PR DESCRIPTION
### Motivation

- Ensure the GUI prompts for and enforces license acceptance at startup so users cannot proceed without opting in. 
- Surface the actual repository `LICENSE` content in the GUI so users can review the agreement before accepting. 
- Provide the missing `hueyos` compatibility modules that test-suite and other code expect to avoid import errors.

### Description

- Updated `apps/huey_gui/main_ui.py` to display the repository `LICENSE`, compute a SHA-256 hash of it, and call a startup `ensure_license_accepted` flow from `MainUI.__init__` that prompts the user and records acceptance. 
- Wired the GUI to call `validate_license_acceptance` and `accept_license` to enforce opt-in and persist acceptance metadata to `~/.hueyos/gui_config.json` (fields: `license.accepted`, `license.accepted_at`, `license.hash`). 
- Added `src/hueyos/license_gui.py` implementing `accept_license(config_path, license_hash)` to load/save acceptance metadata. 
- Added `src/hueyos/install_gui.py` implementing `validate_license_acceptance(accepted)` and `src/hueyos/__init__.py` as a compatibility namespace that forwards to `huey` to satisfy imports expecting `hueyos`.

### Testing

- Ran `pytest -q tests/test_gui.py tests/test_license_gui.py tests/test_install_gui.py` and the selected test suite passed. 
- Result: `17 passed in 0.12s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f27e218c20832faade08ddbc9a9769)