### PR TITLE
Improve PyGPT CLI integration and add hueyos compatibility module

### DIFF
--- a/src/huey/pygpt_custom_cli.py
+++ b/src/huey/pygpt_custom_cli.py
@@ -1,20 +1,18 @@
-"""Custom PyGPT command-line interface stub."""
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: PyGPT custom CLI compatibility wrapper (src)
+
+"""Expose the maintained CustomPyGPT implementation under :mod:`huey`.
+
+This wrapper keeps legacy imports stable while routing to the richer
+implementation in :mod:`huey.memory.PY.pygpt_custom_cli`.
+"""
 
 from __future__ import annotations
 
-from pathlib import Path
+from .memory.PY import pygpt_custom_cli as _pygpt_custom_cli
 
+__all__ = list(getattr(_pygpt_custom_cli, "__all__", ()))
 
-class CustomPyGPT:
-    def __init__(self, prompt_file: str | Path | None = None):
-        self.prompt_file = Path(prompt_file) if prompt_file else None
-        if self.prompt_file and self.prompt_file.exists():
-            self.main_prompt = self.prompt_file.read_text()
-        else:
-            self.main_prompt = "Echo mode"
-
-    def generate_reply(self, message: str) -> str:
-        return f"Echo: {message}"
-
-
-__all__ = ["CustomPyGPT"]
+globals().update({name: getattr(_pygpt_custom_cli, name) for name in __all__})

--- a/src/hueyos/pygpt_custom_cli.py
+++ b/src/hueyos/pygpt_custom_cli.py
@@ -1,0 +1,5 @@
+"""Compatibility module exposing :mod:`huey.pygpt_custom_cli` under :mod:`hueyos`."""
+
+from __future__ import annotations
+
+from huey.pygpt_custom_cli import *  # noqa: F401,F403


### PR DESCRIPTION
### Motivation
- Ensure the maintained `CustomPyGPT` implementation is used consistently across the codebase and avoid keeping a separate thin stub at the top-level.
- Restore and preserve legacy import paths so callers and tests using `hueyos.*` continue to work.

### Description
- Replace the previous top-level stub with a compatibility wrapper in `src/huey/pygpt_custom_cli.py` that re-exports the implementation from `huey.memory.PY.pygpt_custom_cli`.
- Add `src/hueyos/pygpt_custom_cli.py` which forwards imports to `huey.pygpt_custom_cli` to preserve the `hueyos.pygpt_custom_cli` import path.
- Keep the public API stable by re-exporting names via `__all__` and `globals().update(...)` so existing callers are unaffected.

### Testing
- Ran targeted unit tests with `pytest -q tests/test_pygpt_integration.py tests/test_custom_pygpt_cli.py tests/test_run_minimal.py` and all tests passed.
- Test result: `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f280216b1c832fb54be2028c0bf7c7)