### PR TITLE
Harden .gitignore for local secret and generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,25 @@ memory/*
 
 # Local env/config (real env; example stays tracked)
 huey.env
+
+# Local/generated secret-bearing files (keep templates/examples committed)
+config/pygpt_net/config.json
+*.env
+*.env.*
+!.env.example
+!*.env.example
+!*.env.template
+!*.env.sample
+*.apikey
+*.api_key
+apikey.txt
+api_key.txt
+secrets/
+local_secrets/
+**/secrets.local/
+*.p12
+*.jks
+*.keystore
+pip-audit-report*
+safety-report*
+bandit-report*


### PR DESCRIPTION
### Motivation
- Prevent accidental committing of local secret/config outputs and locally generated security reports by expanding ignore rules. 
- Keep example and template files tracked so onboarding templates remain in the repository.

### Description
- Added a dedicated comment block documenting that the rules apply to local/generated secret-bearing files. 
- Added explicit ignore for `config/pygpt_net/config.json` and broad `.env` ignores while preserving common example/template variants (`*.env.example`, `*.env.template`, `*.env.sample`).
- Added common local API-key filename patterns and local secrets directories as ignore rules, and added key-store file patterns (`*.p12`, `*.jks`, `*.keystore`).
- Added ignore patterns for locally generated security scanner reports (`pip-audit`, `safety`, `bandit`).

### Testing
- Searched the repository for ignore files and inspected the repository root `.gitignore` to confirm the new block was added. 
- Reviewed the diff of `.gitignore` to verify the intended patterns were inserted and example/template negations remain present. 
- Verified that only `.gitignore` was affected by this change. 
- All automated checks completed successfully with the expected single-file modification (`.gitignore`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f70028e8c8832fb3fdf7b663f2c8fd)