### PR TITLE
Remove hardcoded Postgres password from dev compose config

### DIFF
--- a/src/huey/memory/YAML/.env.example
+++ b/src/huey/memory/YAML/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to .env before running compose-dev.
+# Example:
+#   cp src/huey/memory/YAML/.env.example src/huey/memory/YAML/.env
+#
+# Set a local development-only password value.
+POSTGRES_PASSWORD=replace-with-local-dev-password

--- a/src/huey/memory/YAML/compose-dev.yaml
+++ b/src/huey/memory/YAML/compose-dev.yaml
@@ -47,7 +47,8 @@ services:
     image: postgres:latest
     environment:
       POSTGRES_USER: dlrp
-      POSTGRES_PASSWORD: dlrp
+      # Fail closed if POSTGRES_PASSWORD is missing.
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
     volumes:
       - db-data:/var/lib/postgresql/data
     networks:


### PR DESCRIPTION
### Motivation
- Remove hardcoded database credentials from the dev compose file, ensure missing credentials fail loudly, and provide an example env file with instructions for local use.

### Description
- Replaced the hardcoded `POSTGRES_PASSWORD` with a fail-closed environment reference (`POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}`) in `src/huey/memory/YAML/compose-dev.yaml`, added `src/huey/memory/YAML/.env.example` containing a placeholder-only `POSTGRES_PASSWORD` and copy instructions, and preserved existing service names and volume mappings.

### Testing
- Attempted to run compose validation with `docker compose -f src/huey/memory/YAML/compose-dev.yaml --env-file src/huey/memory/YAML/.env.example config`, but validation could not be executed in this environment because `docker` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f700a3efa4832f80f01bd006b65a71)