### PR TITLE
Harden Docker Compose image tags

### DIFF
--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -1,4 +1,5 @@
 name: hueyos
+# NOTE: Keep image tag upgrades deliberate and review them in PRs.
 
 x-service-defaults: &service_defaults
   restart: unless-stopped
@@ -20,7 +21,7 @@ services:
       args:
         PYTHON_VERSION: ${HUEY_PYTHON_VERSION:-3.13-bookworm}
         HUEY_EXTRAS: ${HUEY_BUILD_EXTRAS:-ml,data,cloud}
-    image: ${HUEY_IMAGE:-hueyos:latest}
+    image: ${HUEY_IMAGE:-hueyos:0.1.0}
     container_name: ${HUEY_API_CONTAINER:-hueyos-api}
     env_file:
       - ${HUEY_ENV_FILE:-huey.env.example}
@@ -47,7 +48,7 @@ services:
 
   worker:
     <<: *service_defaults
-    image: ${HUEY_IMAGE:-hueyos:latest}
+    image: ${HUEY_IMAGE:-hueyos:0.1.0}
     container_name: ${HUEY_WORKER_CONTAINER:-hueyos-worker}
     command:
       - huey

--- a/infra/docker/docker/docker-compose.yml
+++ b/infra/docker/docker/docker-compose.yml
@@ -1,4 +1,5 @@
 name: monkey-head-project
+# NOTE: Keep image tag upgrades deliberate and review them in PRs.
 
 x-service-defaults: &service_defaults
   init: true
@@ -37,7 +38,7 @@ volumes:
 services:
   dev-env:
     <<: *service_defaults
-    image: monkey-head-project:latest         # tag produced by build
+    image: monkey-head-project:0.1.0-dev         # tag produced by build
     container_name: monkey-head-project
     command:
       - bash

--- a/src/huey/memory/YAML/compose-dev.yaml
+++ b/src/huey/memory/YAML/compose-dev.yaml
@@ -1,3 +1,4 @@
+# NOTE: Keep image tag upgrades deliberate and review them in PRs.
 services:
   dev-env:
     container_name: monkey-head
@@ -8,7 +9,7 @@ services:
       args:
         SOME_ARG: "some_value"
     # Use an image if built externally (optional)
-    image: monkey-head-project:latest
+    image: monkey-head-project:0.1.0-dev
     # Override the default command if needed
     command: /bin/sh
     # Mount source code and additional volumes if desired
@@ -44,7 +45,7 @@ services:
     retries: 3
 
   db:
-    image: postgres:latest
+    image: postgres:16-alpine
     environment:
       POSTGRES_USER: dlrp
       # Fail closed if POSTGRES_PASSWORD is missing.

--- a/src/huey/memory/YML/docker-compose.yml
+++ b/src/huey/memory/YML/docker-compose.yml
@@ -1,4 +1,5 @@
 name: monkey-head-project
+# NOTE: Keep image tag upgrades deliberate and review them in PRs.
 
 x-service-defaults: &service_defaults
   init: true
@@ -28,7 +29,7 @@ volumes:
 services:
   dev-env:
     <<: *service_defaults
-    image: monkey-head-project:latest         # tag produced by build
+    image: monkey-head-project:0.1.0-dev         # tag produced by build
     container_name: monkey-head-project
     build:
       context: .


### PR DESCRIPTION
### Motivation
- Prevent accidental upgrades from floating `:latest` tags by pinning to explicit, maintained tags. 
- Ensure the Postgres dev image is explicit and stable by choosing a major/minor or alpine variant suitable for development. 
- Make image upgrades deliberate and reviewable by adding an in-file note to each modified compose file. 
- Avoid digest pinning unless the repo already uses digests or the digest can be verified from the environment.

### Description
- Replaced `:${HUEY_IMAGE:-hueyos:latest}` with `:${HUEY_IMAGE:-hueyos:0.1.0}` for the `api` and `worker` services in `infra/docker/docker-compose.yml`. 
- Replaced `monkey-head-project:latest` with `monkey-head-project:0.1.0-dev` in `infra/docker/docker/docker-compose.yml`. 
- Updated `src/huey/memory/YAML/compose-dev.yaml` to replace `monkey-head-project:latest` with `monkey-head-project:0.1.0-dev` and `postgres:latest` with `postgres:16-alpine`. 
- Replaced `monkey-head-project:latest` with `monkey-head-project:0.1.0-dev` in `src/huey/memory/YML/docker-compose.yml`, and added a short note at the top of each modified compose file stating that image upgrades should be deliberate and reviewed.

### Testing
- Attempted to run `docker compose -f infra/docker/docker-compose.yml config`, `docker compose -f infra/docker/docker/docker-compose.yml config`, `docker compose -f src/huey/memory/YAML/compose-dev.yaml config`, and `docker compose -f src/huey/memory/YML/docker-compose.yml config`, and all validations failed because the `docker` CLI is not installed in this environment. 
- No additional automated tests were available or run in this environment; file diffs were inspected to confirm only image tags and top-of-file notes were changed and that volumes and published ports were left unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7012e2748832faf3de3d74a3e2345)