### PR TITLE
Harden HUEY_API_TOKEN enforcement outside development

### DIFF
--- a/huey.env.example
+++ b/huey.env.example
@@ -9,12 +9,15 @@
 HUEY_HOST=127.0.0.1
 HUEY_PORT=1995
 
-# Optional bearer token for the FastAPI control surface.
-# When set, every endpoint except /healthz requires:
+# Bearer token for the FastAPI control surface.
+# In development/local (HUEY_ENV=development or local), this may be left empty.
+# In staging/production (or any non-development HUEY_ENV), HueyOS startup fails
+# unless HUEY_API_TOKEN is set to a non-placeholder secret.
+# Every endpoint except /healthz requires:
 #   Authorization: Bearer <token>
-HUEY_API_TOKEN=
+HUEY_API_TOKEN=replace-with-a-strong-secret-token
 
-# Environment: development | staging | production
+# Environment: development | local | staging | production
 HUEY_ENV=development
 
 # Logging level: DEBUG | INFO | WARNING | ERROR

--- a/src/huey/memory/PY/api.py
+++ b/src/huey/memory/PY/api.py
@@ -244,11 +244,57 @@ app = FastAPI(
 
 _PUBLIC_PATHS = {"/healthz"}
 
+_DEVELOPMENT_ENVS = {"", "dev", "development", "local", "test", "testing"}
+_TOKEN_PLACEHOLDER_VALUES = {
+    "changeme",
+    "change-me",
+    "replace-me",
+    "replace_this",
+    "replace-this",
+    "placeholder",
+    "token",
+    "your-token-here",
+    "your_token_here",
+    "set-me",
+    "setme",
+}
+
 
 def _configured_api_token() -> str:
     """Return the optional bearer token required for API access."""
 
     return os.getenv("HUEY_API_TOKEN", "").strip()
+
+
+def _configured_environment() -> str:
+    """Return the deployment environment label used for API security policy."""
+
+    return os.getenv("HUEY_ENV", "").strip().lower()
+
+
+def _looks_like_placeholder_token(token: str) -> bool:
+    """Return ``True`` when ``token`` appears to be a placeholder/example value."""
+
+    compact = token.strip().lower().replace(" ", "")
+    return compact in _TOKEN_PLACEHOLDER_VALUES or compact.startswith("your-")
+
+
+def _validate_api_token_configuration() -> None:
+    """Fail fast when non-development environments do not configure API auth."""
+
+    environment = _configured_environment()
+    if environment in _DEVELOPMENT_ENVS:
+        return
+
+    token = _configured_api_token()
+    if not token or _looks_like_placeholder_token(token):
+        raise RuntimeError(
+            "HUEY_API_TOKEN must be set to a non-placeholder value when HUEY_ENV "
+            "is not development/local."
+        )
+
+
+_validate_api_token_configuration()
 
 
 @app.middleware("http")

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -104,6 +104,30 @@ async def test_api_token_is_required_when_configured(monkeypatch):
     assert allowed.status_code == 200
 
 
+def test_api_startup_fails_without_token_in_non_development_env(monkeypatch):
+    monkeypatch.setenv("HUEY_ENV", "production")
+    monkeypatch.delenv("HUEY_API_TOKEN", raising=False)
+
+    with pytest.raises(RuntimeError, match="HUEY_API_TOKEN must be set"):
+        importlib.reload(api_module)
+
+
+def test_api_startup_fails_with_placeholder_token_in_non_development_env(monkeypatch):
+    monkeypatch.setenv("HUEY_ENV", "staging")
+    monkeypatch.setenv("HUEY_API_TOKEN", "change-me")
+
+    with pytest.raises(RuntimeError, match="HUEY_API_TOKEN must be set"):
+        importlib.reload(api_module)
+
+
+def test_api_startup_allows_missing_token_in_development_env(monkeypatch):
+    monkeypatch.setenv("HUEY_ENV", "development")
+    monkeypatch.delenv("HUEY_API_TOKEN", raising=False)
+
+    reloaded = importlib.reload(api_module)
+    assert reloaded.app is not None
+
+
 def _healthy_snapshot() -> ResourceSnapshot:
     return ResourceSnapshot(
         cpu_percent=10.0,


### PR DESCRIPTION
### Motivation
- Prevent accidental startup of staging/production with no or placeholder API credentials by enforcing token requirements at import/startup time.
- Keep local developer experience unchanged by allowing relaxed behavior in explicit development/local/test environments.
- Preserve existing request-time bearer-token middleware behavior and avoid exposing token values in logs.

### Description
- Add startup-time validation in `src/huey/memory/PY/api.py` that reads `HUEY_ENV` and `HUEY_API_TOKEN`, treats several common example/placeholder strings as invalid, and raises a `RuntimeError` in non-development environments when the token is missing or placeholder-like.
- Add helper functions `_configured_environment()`, `_looks_like_placeholder_token()`, and `_validate_api_token_configuration()` and invoke validation at module import without changing the existing request middleware logic that enforces `Authorization: Bearer <token>`.
- Update `huey.env.example` to document that non-development deployments must set a real secret token and provide a sensible placeholder example value.
- Add tests in `tests/test_api_routes.py` that assert startup fails in `production` when token is absent, fails in `staging` when token is a placeholder, and allows missing token in `development`.
- Files changed: `src/huey/memory/PY/api.py`, `tests/test_api_routes.py`, and `huey.env.example`.

### Testing
- Added unit tests in `tests/test_api_routes.py` to verify startup validation behavior and ran the targeted test collection with `pytest -q tests/test_api_routes.py -k "api_token_is_required_when_configured or api_startup_fails_without_token_in_non_development_env or api_startup_fails_with_placeholder_token_in_non_development_env or api_startup_allows_missing_token_in_development_env"`.
- Test run was interrupted during collection due to an existing import-path issue in the test environment: `ImportError: cannot import name 'api' from 'huey.memory.PY'`, preventing execution of the new assertions in this environment.
- The changes do not log token contents, do not weaken the middleware, and will cause startup to fail fast in any non-development `HUEY_ENV` when `HUEY_API_TOKEN` is empty or looks like a placeholder (development/local/test remain permissive).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f701c97550832f8dba8b683ff1e1c8)