### PR TITLE
Harden admin/GUI/VNC defaults for local-only exposure

### DIFF
--- a/infra/docker/Dockerfile.vnc
+++ b/infra/docker/Dockerfile.vnc
@@ -46,8 +46,12 @@ x11vnc -storepasswd "${VNC_PASSWORD}" "${VNC_PASSWD_FILE}" >/dev/null
 chmod 600 "${VNC_PASSWD_FILE}"
 x11vnc -display :1 -forever -shared -localhost -rfbauth "${VNC_PASSWD_FILE}" -rfbport 5900 &
 
-# noVNC web bridge on port 1995
-websockify --web=/usr/share/novnc/ 1995 localhost:5900 &
+# noVNC web bridge on port 1995 (loopback-bound in-container by default)
+# Publish this port to localhost only on the host. For remote access, prefer:
+#  1) SSH tunnel, or
+#  2) authenticated reverse proxy, or
+#  3) TLS + authentication before exposing beyond localhost.
+websockify --web=/usr/share/novnc/ 127.0.0.1:1995 localhost:5900 &
 
 # Launch PyGPT
 exec pygpt --workdir=/data

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -34,6 +34,9 @@ services:
       - ./config:/app/config
       - ./memory:/app/memory
     ports:
+      # Dev-safe default: publish to loopback only.
+      # Remote access patterns (opt-in): SSH tunnel, authenticated reverse
+      # proxy, or TLS + auth before any non-local exposure.
       - "${HUEY_BIND_ADDR:-127.0.0.1}:${HUEY_PORT:-1995}:1995"
     healthcheck:
       test:

--- a/infra/docker/docker/docker-compose.yml
+++ b/infra/docker/docker/docker-compose.yml
@@ -76,6 +76,9 @@ services:
       # - type: tmpfs
       #   target: /tmp
     ports:
+      # Dev-safe default: loopback-only host publish.
+      # For remote access, keep this opt-in and use SSH tunneling, or put
+      # the service behind an authenticated reverse proxy with TLS.
       - "127.0.0.1:${API_PORT:-1995}:1995"
     expose: ["1995"]
     healthcheck: *api_healthcheck
@@ -107,6 +110,8 @@ services:
     image: subos:local
     profiles: ["subos"]
     ports:
+      # VNC/GUI-adjacent helper service: localhost publish by default.
+      # Non-local exposure must be explicitly protected (TLS + auth).
       - "127.0.0.1:8080:8080"
     networks: [back]
 
@@ -118,6 +123,8 @@ services:
     image: nanoos:local
     profiles: ["nanoos"]
     ports:
+      # VNC/GUI-adjacent helper service: localhost publish by default.
+      # Prefer SSH tunnel or authenticated reverse proxy for remote access.
       - "127.0.0.1:8081:8081"
     networks: [back]
 

--- a/infra/docker/docker/subos/Dockerfile
+++ b/infra/docker/docker/subos/Dockerfile
@@ -70,5 +70,9 @@ RUN chmod +x "$HOME/.vnc/xstartup"
 # Expose the necessary port(s)
 EXPOSE 5901
 
-# Define the command to run when the container starts
+# Define the command to run when the container starts.
+# `-localhost yes` keeps VNC loopback-only in the container by default.
+# When publishing this port on a host, keep it at 127.0.0.1 unless you
+# explicitly add TLS + auth (or place it behind an authenticated proxy).
+# SSH tunneling is the preferred remote-access pattern.
 CMD ["/usr/local/bin/start-vnc.sh", "-geometry", "1280x800", "-depth", "24", "-localhost", "yes", ":1"]


### PR DESCRIPTION
### Motivation
- Reduce accidental remote exposure of VNC/noVNC and admin GUI surfaces by preferring loopback bindings for dev/admin services. 
- Ensure `VNC_PASSWORD` remains required at runtime so VNC access is always authenticated. 
- Document safe, opt-in remote access patterns (SSH tunnel, authenticated reverse proxy, TLS+auth) for operators.

### Description
- Bind the noVNC web bridge inside the container to loopback by changing `websockify` to `127.0.0.1:1995` in `infra/docker/Dockerfile.vnc` and add inline guidance about secure remote access. 
- Add explanatory comments to `infra/docker/docker-compose.yml` and `infra/docker/docker/docker-compose.yml` to prefer host publish of dev/admin ports to `127.0.0.1` and document opt-in remote access patterns. 
- Add comments to `infra/docker/docker/subos/Dockerfile` and keep the `-localhost yes` option in the VNC startup `CMD` so the container keeps VNC loopback-only by default. 
- Confirmed that `VNC_PASSWORD` is required in both `infra/docker/Dockerfile.vnc` and `infra/docker/docker/subos/Dockerfile` startup wrappers and was not hardcoded anywhere.

### Testing
- Attempted Compose file syntax validation with `docker compose -f infra/docker/docker-compose.yml config` and `docker compose -f infra/docker/docker/docker-compose.yml config`, but the Docker CLI was unavailable in this environment (`docker: command not found`), so syntax checks could not be completed.
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7029136d8832f9e9f4271c920073c)