### PR TITLE
Add GitHub Actions workflow for dependency vulnerability scanning

### DIFF
--- a/.github/workflows/security-dependency-scan.yml
+++ b/.github/workflows/security-dependency-scan.yml
@@ -1,0 +1,43 @@
+name: Dependency Security Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install pip-audit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pip-audit
+
+      - name: Run pip-audit (human-readable)
+        run: pip-audit -r requirements.txt
+
+      - name: Run pip-audit (JSON output)
+        run: pip-audit -r requirements.txt --format json --output pip-audit-results.json
+
+      - name: Upload pip-audit results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pip-audit-results
+          path: pip-audit-results.json
+          if-no-files-found: error


### PR DESCRIPTION
### Motivation
- Add an automated dependency vulnerability scan using `pip-audit` to satisfy the repo’s security guidance and address the `SECURITY_INVENTORY.md` recommendation to add CI vulnerability gates. 
- Ensure scans run regularly and on relevant events (PRs, pushes to main/master, weekly, and manual runs) so vulnerabilities are caught early.

### Description
- Add file `.github/workflows/security-dependency-scan.yml` which triggers on `pull_request`, `push` to `main`/`master`, a weekly schedule, and `workflow_dispatch` for manual runs. 
- The job uses `actions/checkout@v6`, `actions/setup-python@v6` with `python-version: '3.13'`, installs `pip-audit`, runs a human-readable scan (`pip-audit -r requirements.txt`) and a JSON-output scan (`pip-audit -r requirements.txt --format json --output pip-audit-results.json`), and uploads `pip-audit-results.json` via `actions/upload-artifact@v7`. 
- The artifact upload is guarded with `if: always()` so results are retained even if the job fails, and the workflow intentionally does not add suppressions so it will fail on discovered vulnerabilities by default. 
- To run manually use the Actions UI (open the “Dependency Security Scan” workflow and click “Run workflow”) or via CLI: `gh workflow run security-dependency-scan.yml`.

### Testing
- No automated repository tests were executed as part of this change because the modification is a CI workflow addition only; verification is performed by running the workflow in GitHub Actions (manual or scheduled runs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f703434700832fa3f6bd76feeb86a9)