### PR TITLE
Add Bandit GitHub Actions security scan with JSON artifact

### DIFF
--- a/.github/workflows/security-bandit.yml
+++ b/.github/workflows/security-bandit.yml
@@ -1,0 +1,49 @@
+name: Bandit Security Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+jobs:
+  bandit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install Bandit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install bandit
+
+      - name: Run Bandit (human-readable)
+        run: |
+          bandit -r src tests integrations scripts platform infra apps tools run.py conftest.py \
+            -x "**/.venv/**,**/venv/**,**/env/**,**/__pycache__/**,**/.pytest_cache/**,**/.mypy_cache/**,**/.ruff_cache/**,**/.tox/**,**/build/**,**/dist/**,**/*.egg-info/**,**/vendor/**,**/node_modules/**"
+
+      - name: Run Bandit (JSON output)
+        if: always()
+        run: |
+          bandit -r src tests integrations scripts platform infra apps tools run.py conftest.py \
+            -x "**/.venv/**,**/venv/**,**/env/**,**/__pycache__/**,**/.pytest_cache/**,**/.mypy_cache/**,**/.ruff_cache/**,**/.tox/**,**/build/**,**/dist/**,**/*.egg-info/**,**/vendor/**,**/node_modules/**" \
+            -f json -o bandit-results.json
+
+      - name: Upload Bandit JSON results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bandit-results
+          path: bandit-results.json
+          if-no-files-found: error


### PR DESCRIPTION
### Motivation
- Add a repository-level static security scan for Python code using Bandit so CI surface s common security issues. 
- Report findings in both human-readable form and a machine-readable JSON artifact without automatically suppressing any results.

### Description
- Added a new workflow at ` .github/workflows/security-bandit.yml` that runs on `pull_request`, pushes to `main`/`master`, a weekly schedule, and manual dispatch. 
- Configured Bandit to recursively scan `src`, `tests`, `integrations`, `scripts`, `platform`, `infra`, `apps`, `tools`, `run.py`, and `conftest.py`. 
- Excluded typical virtualenvs, caches, build artifacts, and vendored/binary dirs with the patterns `**/.venv/**`, `**/venv/**`, `**/env/**`, `**/__pycache__/**`, `**/.pytest_cache/**`, `**/.mypy_cache/**`, `**/.ruff_cache/**`, `**/.tox/**`, `**/build/**`, `**/dist/**`, `**/*.egg-info/**`, `**/vendor/**`, and `**/node_modules/**`. 
- Produces human-readable console output and JSON output written to `bandit-results.json`, which is uploaded as an artifact named `bandit-results`, and does not apply any automatic suppression of findings; no Bandit config file was detected so the workflow uses explicit targets and excludes. 

### Testing
- Verified existing workflows with `rg --files .github/workflows` and found the new workflow alongside existing CI files (succeeded). 
- Searched for existing Bandit configuration keys with `rg -n "\[tool.bandit\]|exclude_dirs|skips|targets"` and confirmed no repo-level Bandit config was found (succeeded). 
- Enumerated Python source top-level directories with a small Python script to confirm scan targets include the main code paths (succeeded). 
- Inspected the created workflow file with `nl -ba .github/workflows/security-bandit.yml` to verify contents and the JSON artifact step (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7050ad7e4832fbe46ccee7576b642)