### PR TITLE
Add explicit workflow permissions to security scans

### DIFF
--- a/.github/workflows/security-bandit.yml
+++ b/.github/workflows/security-bandit.yml
@@ -10,6 +10,10 @@ on:
     - cron: '0 7 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+
 jobs:
   bandit:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-dependency-scan.yml
+++ b/.github/workflows/security-dependency-scan.yml
@@ -10,6 +10,10 @@ on:
     - cron: '0 6 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+
 jobs:
   pip-audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation
- The dependency scan and Bandit workflows had no explicit `permissions` block and therefore relied on repository/organization defaults which can be broader than necessary; declaring least-privilege permissions documents intent and reduces token scope.

### Description
- Add a top-level `permissions` block with `contents: read` to ` .github/workflows/security-dependency-scan.yml` and ` .github/workflows/security-bandit.yml` to enforce least-privilege for the workflow token.

### Testing
- Verified the change surface with `git diff -- .github/workflows/security-dependency-scan.yml .github/workflows/security-bandit.yml` and committed the updates with `git commit -m "Add explicit least-privilege permissions to security workflows"`, both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7775d66f0832fa929048b8761e0db)