### PR TITLE
Harden task/dashboard command surfaces and add command-surface audit

### DIFF
--- a/SECURITY_COMMAND_SURFACE.md
+++ b/SECURITY_COMMAND_SURFACE.md
@@ -1,0 +1,24 @@
+# SECURITY_COMMAND_SURFACE
+
+This document inventories command/task execution surfaces reviewed in this audit.
+
+| File / Function | Source of input | Reachable remotely | Existing auth / gating | Risk | Recommended fix |
+|---|---|---:|---|---|---|
+| `src/huey/core/task_scheduler.py` / `TaskScheduler.submit_task` | `command: str` provided by API request or dashboard operator | Indirectly (via API), local GUI direct | Scheduler itself does not execute shell; queues metadata and dispatch state only | **Medium** (free-form command intent preserved for downstream agents) | Keep scheduler execution-free; require strict access controls at submission layers and validate command schema when execution backend is added. |
+| `src/huey/memory/PY/api.py` / `submit_task` (`POST /tasks`) | JSON body field `command` | Yes | Existing bearer token middleware when `HUEY_API_TOKEN` configured; **added** local-only guard when token unset | **High** before guard, **Medium** after guard | Keep bearer token mandatory for remote usage; consider command allow-lists per agent capability. |
+| `src/huey/memory/PY/api.py` / `dashboard` (`GET /dashboard`) | HTTP request (operator session) and displayed task commands | Yes | Existing bearer token middleware when token set; **added** local-only guard when token unset | **Medium** | Keep as operator surface only; avoid rendering sensitive command payloads to unauthenticated users. |
+| `src/huey/memory/PY/dashboard.py` / `DashboardWindow._submit_task_dialog` | Free-form GUI text input | Local desktop operator only | Local interactive GUI, no network exposure by itself | **Medium** | Add explicit developer/operator warning in UI copy when tasks may trigger command execution in downstream agents. |
+| `src/huey/memory/PY/commands.py` / `run_command` | Call-site argv sequence | Depends on caller | Uses argv list (`subprocess.run(list(cmd))`), not shell string | **Low** | Preserve argv-only contract; do not accept unparsed free-form shell strings. |
+| `src/huey/pygpt_net/tools/manager/__init__.py` / tool runner | Tool registry values forming argv list | Potentially local/automation | Uses list-based `subprocess.run(cmd, check=False)` | **Medium** | Enforce trusted tool registry entries and log provenance of selected command. |
+
+## Explicit checks performed
+
+- Reviewed scheduler submission and API task/dashboard paths.
+- Searched for `shell=True`; no hits in `src/huey` / `src/hueyos`.
+- Searched for `eval(` / `exec(`; no dynamic code execution hits related to command surfaces.
+- Confirmed subprocess usage in maintained paths is argv/list-based.
+
+## Notes
+
+- No obvious `shell=True` usage was found in maintained Python sources under `src/huey` and `src/hueyos`, so no shell-to-argv conversion patch was required in this audit.
+- Developer-only task entry points are preserved; this change narrows unauthenticated remote exposure by enforcing local-only behavior when no API token is configured.

--- a/src/huey/memory/PY/api.py
+++ b/src/huey/memory/PY/api.py
@@ -297,6 +297,35 @@ def _validate_api_token_configuration() -> None:
 _validate_api_token_configuration()
 
 
+def _is_local_request(request: Request) -> bool:
+    """Return ``True`` when the caller appears to be local to this host."""
+
+    client = getattr(request, "client", None)
+    host = getattr(client, "host", "") if client is not None else ""
+    return host in {"127.0.0.1", "::1", "localhost", "testclient", "testserver"}
+
+
+def _require_privileged_surface_access(request: Request) -> None:
+    """Protect command/task surfaces when global bearer auth is not configured.
+
+    These endpoints accept free-form task instructions that can eventually map to
+    agent command execution. When ``HUEY_API_TOKEN`` is unset we allow local-only
+    access for developer workflows and block remote access by default.
+    """
+
+    if _configured_api_token():
+        return
+    if _is_local_request(request):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=(
+            "This endpoint requires local access when HUEY_API_TOKEN is unset. "
+            "Configure HUEY_API_TOKEN for remote access."
+        ),
+    )
+
+
 @app.middleware("http")
 async def require_api_token(request: Request, call_next):
     """Require a bearer token when HUEY_API_TOKEN is configured."""
@@ -1258,9 +1287,10 @@ def healthz() -> Dict[str, str]:
     status_code=status.HTTP_202_ACCEPTED,
     tags=["Task Management"],
 )
-def submit_task(request: TaskSubmissionRequest) -> TaskResponse:
+def submit_task(request: TaskSubmissionRequest, http_request: Request) -> TaskResponse:
     """Submit a task for execution by Spark or Zap."""
 
+    _require_privileged_surface_access(http_request)
     profile = (
         request.resource_profile.to_profile()
         if request.resource_profile is not None
@@ -1545,9 +1575,10 @@ def list_recent_ai_interactions(
 
 
 @app.get("/dashboard", response_class=HTMLResponse, tags=["Dashboard"])
-def dashboard() -> HTMLResponse:
+def dashboard(request: Request) -> HTMLResponse:
     """Render a lightweight operational dashboard for HueyOS."""
 
+    _require_privileged_surface_access(request)
     system = _build_system_status()
     battery = BATTERY_MONITOR.get_status()
     sensor_records = TELEMETRY_STORE.fetch_recent_sensor_readings(limit=10)

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -189,6 +189,21 @@ async def test_task_submission_respects_resource_constraints(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_task_and_dashboard_surfaces_block_remote_when_token_unset(monkeypatch):
+    monkeypatch.delenv("HUEY_API_TOKEN", raising=False)
+    scheduler = TaskScheduler(health_provider=_healthy_snapshot)
+    monkeypatch.setattr(api_module, "SCHEDULER", scheduler, raising=False)
+
+    transport = ASGITransport(app=api_module.app)
+    async with AsyncClient(transport=transport, base_url="http://198.51.100.10") as client:
+        submit = await client.post("/tasks", json={"command": "calibrate sensors"})
+        dashboard = await client.get("/dashboard")
+
+    assert submit.status_code == 403
+    assert dashboard.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_system_status_endpoint_reports_expected_fields(monkeypatch, tmp_path):
     memory_root = tmp_path / "memory"
     memory_root.mkdir()


### PR DESCRIPTION
### Motivation

- Reduce remote exposure of free-form task/command surfaces that can carry user-controlled intent to downstream execution systems.  
- Preserve developer/local workflows while preventing unauthenticated remote task submission when `HUEY_API_TOKEN` is not configured.  
- Produce an auditable inventory of command-execution surfaces to guide follow-up hardening work.

### Description

- Add `SECURITY_COMMAND_SURFACE.md` documenting each command/task surface, its input source, remote reachability, current gating, risk rating, and recommended fixes.  
- Add helper guards in `src/huey/memory/PY/api.py`: `_is_local_request(request)` and `_require_privileged_surface_access(request)` to centralize local-vs-remote access policy.  
- Enforce the guard on sensitive endpoints so that `POST /tasks` and `GET /dashboard` require either a configured bearer token or local-only access when `HUEY_API_TOKEN` is unset.  
- Add a regression test `test_task_and_dashboard_surfaces_block_remote_when_token_unset` in `tests/test_api_routes.py` to assert remote unauthenticated access is rejected with HTTP 403 when no token is configured.

### Testing

- Ran `python -m py_compile src/huey/memory/PY/api.py tests/test_api_routes.py`, which completed successfully.  
- Executed a focused `pytest` run for impacted API tests, which failed during collection with an `ImportError: cannot import name 'api' from 'huey.memory.PY'` preventing full test execution.  
- Because collection failed, the new regression test could not be exercised end-to-end in this environment; the code changes are lint/compile-checked but require resolving the import issue in the test environment before all tests can pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7a73ccbf0832f8d1173100ce112ed)