### PR TITLE
Harden free-form task submission with explicit unsafe-task gating

### DIFF
--- a/src/huey/memory/PY/api.py
+++ b/src/huey/memory/PY/api.py
@@ -272,6 +272,13 @@ def _configured_environment() -> str:
     return os.getenv("HUEY_ENV", "").strip().lower()
 
 
+def _unsafe_task_submission_enabled() -> bool:
+    """Return whether unsafe/free-form task submission is explicitly enabled."""
+
+    value = os.getenv("HUEY_ENABLE_UNSAFE_TASKS", "false").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
 def _looks_like_placeholder_token(token: str) -> bool:
     """Return ``True`` when ``token`` appears to be a placeholder/example value."""
 
@@ -322,6 +329,32 @@ def _require_privileged_surface_access(request: Request) -> None:
         detail=(
             "This endpoint requires local access when HUEY_API_TOKEN is unset. "
             "Configure HUEY_API_TOKEN for remote access."
+        ),
+    )
+
+
+def _require_unsafe_task_submission_access(request: Request) -> None:
+    """Enforce defensive gating for free-form task submission surfaces.
+
+    Policy:
+    - Local developer workflows remain available when the API token is unset.
+    - Remote/production usage requires authenticated API access plus explicit
+      enablement through ``HUEY_ENABLE_UNSAFE_TASKS=true``.
+    """
+
+    _require_privileged_surface_access(request)
+
+    if _unsafe_task_submission_enabled():
+        return
+
+    if _configured_api_token() and _configured_environment() in _DEVELOPMENT_ENVS:
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=(
+            "Unsafe free-form task submission is disabled. Set "
+            "HUEY_ENABLE_UNSAFE_TASKS=true to allow authenticated submission."
         ),
     )
 
@@ -1290,7 +1323,7 @@ def healthz() -> Dict[str, str]:
 def submit_task(request: TaskSubmissionRequest, http_request: Request) -> TaskResponse:
     """Submit a task for execution by Spark or Zap."""
 
-    _require_privileged_surface_access(http_request)
+    _require_unsafe_task_submission_access(http_request)
     profile = (
         request.resource_profile.to_profile()
         if request.resource_profile is not None

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -150,6 +150,7 @@ def _degraded_snapshot() -> ResourceSnapshot:
 async def test_task_management_endpoints_support_submission_and_cancellation(
     monkeypatch,
 ):
+    monkeypatch.setenv("HUEY_ENABLE_UNSAFE_TASKS", "true")
     scheduler = TaskScheduler(health_provider=_healthy_snapshot)
     monkeypatch.setattr(api_module, "SCHEDULER", scheduler, raising=False)
 
@@ -177,6 +178,7 @@ async def test_task_management_endpoints_support_submission_and_cancellation(
 
 @pytest.mark.asyncio
 async def test_task_submission_respects_resource_constraints(monkeypatch):
+    monkeypatch.setenv("HUEY_ENABLE_UNSAFE_TASKS", "true")
     scheduler = TaskScheduler(health_provider=_degraded_snapshot)
     monkeypatch.setattr(api_module, "SCHEDULER", scheduler, raising=False)
 
@@ -191,6 +193,7 @@ async def test_task_submission_respects_resource_constraints(monkeypatch):
 @pytest.mark.asyncio
 async def test_task_and_dashboard_surfaces_block_remote_when_token_unset(monkeypatch):
     monkeypatch.delenv("HUEY_API_TOKEN", raising=False)
+    monkeypatch.delenv("HUEY_ENABLE_UNSAFE_TASKS", raising=False)
     scheduler = TaskScheduler(health_provider=_healthy_snapshot)
     monkeypatch.setattr(api_module, "SCHEDULER", scheduler, raising=False)
 
@@ -201,6 +204,65 @@ async def test_task_and_dashboard_surfaces_block_remote_when_token_unset(monkeyp
 
     assert submit.status_code == 403
     assert dashboard.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_task_submission_denied_by_default_without_unsafe_flag(monkeypatch):
+    monkeypatch.delenv("HUEY_API_TOKEN", raising=False)
+    monkeypatch.delenv("HUEY_ENABLE_UNSAFE_TASKS", raising=False)
+    scheduler = TaskScheduler(health_provider=_healthy_snapshot)
+    monkeypatch.setattr(api_module, "SCHEDULER", scheduler, raising=False)
+
+    transport = ASGITransport(app=api_module.app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        submit = await client.post("/tasks", json={"command": "echo secret-token"})
+
+    assert submit.status_code == 403
+    assert "disabled" in submit.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_task_submission_allowed_for_development_with_unsafe_flag(monkeypatch):
+    monkeypatch.delenv("HUEY_API_TOKEN", raising=False)
+    monkeypatch.setenv("HUEY_ENABLE_UNSAFE_TASKS", "true")
+    monkeypatch.setenv("HUEY_ENV", "development")
+    scheduler = TaskScheduler(health_provider=_healthy_snapshot)
+    monkeypatch.setattr(api_module, "SCHEDULER", scheduler, raising=False)
+
+    transport = ASGITransport(app=api_module.app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        submit = await client.post("/tasks", json={"command": "calibrate sensors"})
+
+    assert submit.status_code == 202
+
+
+@pytest.mark.asyncio
+async def test_task_submission_requires_unsafe_flag_even_when_authenticated(monkeypatch):
+    monkeypatch.setenv("HUEY_API_TOKEN", "test-token")
+    monkeypatch.setenv("HUEY_ENV", "production")
+    monkeypatch.delenv("HUEY_ENABLE_UNSAFE_TASKS", raising=False)
+    scheduler = TaskScheduler(health_provider=_healthy_snapshot)
+    monkeypatch.setattr(api_module, "SCHEDULER", scheduler, raising=False)
+
+    transport = ASGITransport(app=api_module.app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        denied = await client.post(
+            "/tasks",
+            json={"command": "calibrate sensors"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+    assert denied.status_code == 403
+    monkeypatch.setenv("HUEY_ENABLE_UNSAFE_TASKS", "true")
+    transport2 = ASGITransport(app=api_module.app)
+    async with AsyncClient(transport=transport2, base_url="http://testserver") as client:
+        enabled = await client.post(
+            "/tasks",
+            json={"command": "calibrate sensors"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+    assert enabled.status_code == 202
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Free-form task/command submissions to the scheduler were identified as a risky attack surface in `SECURITY_COMMAND_SURFACE.md` and need server-side gating. 
- Prevent remote, unauthenticated submission of arbitrary instructions and avoid relying on frontend hiding. 
- Provide an explicit opt-in mechanism for developers/operators to enable unsafe flows when appropriate.

### Description
- Added a new environment/config flag `HUEY_ENABLE_UNSAFE_TASKS` (defaults to disabled) and helper `_unsafe_task_submission_enabled()` to parse truthy values. 
- Implemented `_require_unsafe_task_submission_access()` in `src/huey/memory/PY/api.py` and invoked it from the `POST /tasks` handler so submission is defensively gated at the API boundary. 
- Policy enforced: local-only access remains when token is unset, and production/staging remote submission requires explicit `HUEY_ENABLE_UNSAFE_TASKS=true` (and bearer auth where configured). 
- Updated and added tests in `tests/test_api_routes.py` to cover default denial, development allow-listing with the flag, and the authenticated-but-disabled path; existing tests that expect submission now set the unsafe flag explicitly.

### Testing
- Added unit tests covering: default denial without `HUEY_ENABLE_UNSAFE_TASKS`, allowed development behavior with `HUEY_ENABLE_UNSAFE_TASKS=true`, and authenticated submission requiring the unsafe flag. 
- Ran a targeted test invocation `pytest -q tests/test_api_routes.py -k "task_submission or task_management_endpoints_support_submission_and_cancellation or task_and_dashboard_surfaces_block_remote_when_token_unset"` which failed during collection with an ImportError (`cannot import name 'api' from 'huey.memory.PY'`) preventing full execution of the new tests. 
- Tests have been updated and committed; follow-up CI or a subsequent local test run is recommended to validate the full test-suite in the test environment that mirrors import paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7a8782ef8832f95baff82f8ea029a)