### PR TITLE
Harden GitHub Actions by pinning action revisions

### DIFF
--- a/.github/SECURITY_WORKFLOW_NOTES.md
+++ b/.github/SECURITY_WORKFLOW_NOTES.md
@@ -1,0 +1,17 @@
+# GitHub Actions Security Workflow Notes
+
+## Policy
+- Prefer immutable action references pinned to full commit SHAs.
+- Track the upstream major tag in a trailing comment (for example `# v6`) to preserve upgrade intent.
+- Default workflow token permissions to least privilege (`contents: read`) and only add write scopes when required by a job.
+- Keep behavior changes out of hardening-only updates; only action pinning and permission minimization are in scope.
+
+## Reviewed action pins
+- `actions/checkout` pinned to commit `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (upstream `v6`).
+- `actions/setup-python` pinned to commit `a309ff8b426b58ec0e2a45f0f869d46889d02405` (upstream `v6`).
+- `actions/upload-artifact` pinned to commit `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (upstream `v7`).
+- `github/codeql-action` (`init`, `analyze`) pinned to commit `ed410739ba306e4ebe5e123421a6bd694e494a2b` (upstream `v4`).
+
+## Permission baseline
+- Workflow-level `permissions: contents: read` is preferred.
+- CodeQL keeps additional permissions required to upload analysis (`security-events: write`) and read packages/actions where needed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
           cache: "pip"
@@ -59,12 +59,12 @@ jobs:
         python-version: [ "3.13" ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload coverage artifacts (if present)
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-${{ matrix.python-version }}
           path: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,11 +57,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@ed410739ba306e4ebe5e123421a6bd694e494a2b # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -80,6 +80,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@ed410739ba306e4ebe5e123421a6bd694e494a2b # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/security-bandit.yml
+++ b/.github/workflows/security-bandit.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.13'
 
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload Bandit JSON results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: bandit-results
           path: bandit-results.json

--- a/.github/workflows/security-dependency-scan.yml
+++ b/.github/workflows/security-dependency-scan.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.13'
 
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload pip-audit results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pip-audit-results
           path: pip-audit-results.json


### PR DESCRIPTION
### Motivation
- Reduce supply-chain risk by replacing mutable action version tags with reviewed immutable pins while preserving upgrade intent. 
- Keep workflow behavior unchanged and maintain least-privilege token permissions as a security baseline.

### Description
- Replaced mutable `uses:` action tags in workflows with reviewed immutable commit-pinned references and left the upstream major tag as a trailing comment for traceability (for example `# v6`, `# v7`, `# v4`).
- Workflows updated: `.github/workflows/ci.yml`, `.github/workflows/codeql.yml`, `.github/workflows/security-bandit.yml`, and `.github/workflows/security-dependency-scan.yml`.
- Key action references hardened include `actions/checkout` (previously `@v6`), `actions/setup-python` (previously `@v6`), `actions/upload-artifact` (previously `@v7`), and `github/codeql-action` (init/analyze, previously `@v4`).
- Added `.github/SECURITY_WORKFLOW_NOTES.md` documenting the pinning policy, reviewed pins, and the permission baseline; no CI logic or secrets were changed.

### Testing
- Verified workflow files present with `rg --files .github/workflows` and inspected contents with `sed -n` on each workflow file; all reads succeeded.
- Confirmed upstream tags resolve and used `git ls-remote` to validate the referenced tags exist; resolution checks succeeded.
- Scanned workflows for `uses:` entries with `rg -n "uses:" .github/workflows/*.yml` and validated the pin replacements via `git diff -- .github/workflows .github/SECURITY_WORKFLOW_NOTES.md`; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7bb1da948832fa7370bd5c5ef1d77)