### PR TITLE
Pin Docker image references and add container image update policy

### DIFF
--- a/docs/security/docker-image-policy.md
+++ b/docs/security/docker-image-policy.md
@@ -1,0 +1,33 @@
+# Docker Image Pinning & Update Policy
+
+This repository uses Docker images in both development and runtime workflows. To reduce supply-chain risk and avoid surprise breakage, follow these rules:
+
+## 1) No `:latest` in committed Compose files
+
+- Do not commit Compose services that reference floating `:latest` tags.
+- Use explicit versioned tags (for example `redis:7.2-alpine`) or internal build tags (for example `monkey-head-project:0.1.0-dev`).
+
+## 2) Base image upgrades must be reviewed
+
+- Treat base image tag changes as code changes that require pull-request review.
+- When updating a base image, document:
+  - old tag -> new tag,
+  - motivation (security fix, compatibility, feature),
+  - any expected runtime impact.
+
+## 3) Digest pinning for production/release images
+
+- Production/release images should be pinned by digest in release manifests, e.g. `image: repo/name:tag@sha256:<digest>`.
+- Development Compose stacks may use explicit tags without digests to preserve local workflow flexibility.
+
+## 4) Scheduled rebuild expectations
+
+- Rebuild development images at least monthly to pick up OS/package security updates.
+- Rebuild production/release images on a fixed cadence (at least monthly) and immediately for critical CVEs.
+- Even with unchanged application code, produce refreshed images to capture upstream security patches.
+
+## 5) Debian release track defaults in this repo
+
+- `bookworm` defaults are treated as stable/runtime-oriented.
+- `forky` defaults are treated as **development/testing track** and are intentionally mutable over time.
+- Any Dockerfile using `ARG DEBIAN_RELEASE=forky` or `ARG DEBIAN_VERSION=forky` must include a comment noting this is an intentional dev/testing default.

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.13-bookworm
+ARG PYTHON_VERSION=3.13.5-bookworm
 FROM python:${PYTHON_VERSION}
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -72,7 +72,7 @@ services:
 
   redis:
     <<: *service_defaults
-    image: redis:7-alpine
+    image: redis:7.2-alpine
     container_name: ${HUEY_REDIS_CONTAINER:-hueyos-redis}
     command: ["redis-server", "--appendonly", "yes"]
     volumes:

--- a/infra/docker/docker/Dockerfile
+++ b/infra/docker/docker/Dockerfile
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
+# Default `forky` intentionally follows Debian testing for active development images.
+# Override to a stable release (for example `bookworm`) for release-oriented builds.
 ARG DEBIAN_VERSION=forky
 ARG DEBIAN_VARIANT=slim
 ARG PYTHON_VERSION=3.13.5

--- a/infra/docker/docker/docker-compose.yml
+++ b/infra/docker/docker/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   debian-tools:
     <<: *service_defaults
-    image: debian:forky
+    image: debian:bookworm
     profiles: ["tools"]
     command: ["sleep", "infinity"]
     working_dir: /workspace
@@ -131,7 +131,7 @@ services:
   # Optional example dependency (enable with --profile extras)
   redis:
     <<: *service_defaults
-    image: redis:7-alpine
+    image: redis:7.2-alpine
     profiles: ["extras"]
     command: ["redis-server", "--appendonly", "yes"]
     healthcheck:

--- a/infra/docker/docker/hostos/Dockerfile
+++ b/infra/docker/docker/hostos/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.7
 # HostOS toolbox image
+# `forky` is intentional here to track Debian testing for development-oriented helper images.
 FROM debian:forky-slim
 
 ENV DEBIAN_FRONTEND=noninteractive \

--- a/infra/docker/docker/nanoos/Dockerfile
+++ b/infra/docker/docker/nanoos/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.7
 # NanoOS image (lightweight worker)
+# `forky` is intentional here to track Debian testing for development-oriented helper images.
 FROM debian:forky-slim
 
 ENV DEBIAN_FRONTEND=noninteractive \

--- a/infra/docker/docker/subos/Dockerfile
+++ b/infra/docker/docker/subos/Dockerfile
@@ -1,4 +1,5 @@
-# Use Debian slim base image; release can be overridden at build time
+# Use Debian slim base image; release can be overridden at build time.
+# Default `forky` intentionally tracks Debian testing for development images (not production).
 ARG DEBIAN_RELEASE=forky
 FROM debian:${DEBIAN_RELEASE}-slim
 


### PR DESCRIPTION
### Motivation

- Reduce supply-chain and accidental drift by pinning ambiguous or floating image selectors used in builds and compose files. 
- Make it explicit when Debian `forky` is used as an intentional development/testing track so release workflows are not affected. 
- Provide a short, actionable policy that documents pinning, review, digest usage and rebuild expectations.

### Description

- Pin the Python base selector in `infra/docker/Dockerfile` from a floating minor tag to an explicit patch tag by setting `ARG PYTHON_VERSION=3.13.5-bookworm`. 
- Add explicit comments to Dockerfiles that default to `forky` (for example `infra/docker/docker/Dockerfile`, `infra/docker/docker/subos/Dockerfile`, `infra/docker/docker/hostos/Dockerfile`, `infra/docker/docker/nanoos/Dockerfile`) so the `forky` testing-track default is documented as intentional. 
- Tighten compose image references by replacing `redis:7-alpine` with `redis:7.2-alpine` in the compose files and change the `debian-tools` helper service from `debian:forky` to `debian:bookworm` in `infra/docker/docker/docker-compose.yml`. 
- Add `docs/security/docker-image-policy.md` documenting repository rules for image pinning and update cadence, including no `:latest` in committed compose files, review requirements for base image upgrades, digest pinning guidance for production, scheduled rebuild expectations, and guidance about `bookworm` vs `forky` track intent.

Changed image references

- `python:${PYTHON_VERSION}` default in `infra/docker/Dockerfile`: `3.13-bookworm` → `3.13.5-bookworm`. 
- `redis:7-alpine` → `redis:7.2-alpine` (in `infra/docker/docker-compose.yml` and `infra/docker/docker/docker-compose.yml`). 
- `debian:forky` → `debian:bookworm` for the `debian-tools` service in `infra/docker/docker/docker-compose.yml`.

### Testing

- Attempted `docker compose -f infra/docker/docker-compose.yml config` but it failed because the `docker` CLI is not available in this environment. 
- Attempted `docker compose -f infra/docker/docker/docker-compose.yml config` but it failed for the same reason (no `docker` CLI available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7bc4af928832f8fe3efca21826b15)