### PR TITLE
Add artifact & container-adjacent security scanning workflow

### DIFF
--- a/.github/workflows/security-artifact-container-scan.yml
+++ b/.github/workflows/security-artifact-container-scan.yml
@@ -1,0 +1,131 @@
+name: Artifact & Container-Adjacent Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+  schedule:
+    - cron: '30 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  artifact-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Detect large files and binary-like artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import pathlib
+          import subprocess
+
+          THRESHOLDS = [
+              (1 * 1024 * 1024, "1MB"),
+              (5 * 1024 * 1024, "5MB"),
+              (25 * 1024 * 1024, "25MB"),
+              (50 * 1024 * 1024, "50MB"),
+              (100 * 1024 * 1024, "100MB"),
+          ]
+          BINARY_EXTS = {
+              ".iso", ".img", ".bin", ".exe", ".dll", ".so", ".dylib", ".deb", ".rpm",
+              ".jar", ".war", ".ear", ".apk", ".msi", ".zip", ".7z", ".gz", ".tgz", ".xz",
+              ".bz2", ".pdf", ".mp4", ".mov", ".avi", ".mkv", ".mp3", ".flac", ".wav",
+          }
+
+          files = subprocess.check_output(["git", "ls-files", "-z"], text=False).split(b"\x00")
+          files = [f.decode("utf-8", "replace") for f in files if f]
+
+          records = []
+          for rel in files:
+              p = pathlib.Path(rel)
+              if not p.exists() or not p.is_file():
+                  continue
+              size = p.stat().st_size
+              ext = p.suffix.lower()
+              suspected_binary = ext in BINARY_EXTS
+              records.append({
+                  "path": rel,
+                  "bytes": size,
+                  "extension": ext,
+                  "binary_extension": suspected_binary,
+              })
+
+          records.sort(key=lambda r: r["bytes"], reverse=True)
+
+          with open("large-files-top200.json", "w", encoding="utf-8") as f:
+              json.dump(records[:200], f, indent=2)
+
+          lines = ["# Large and Binary-Adjacent Repository Artifact Report", ""]
+          for limit, label in THRESHOLDS:
+              matched = [r for r in records if r["bytes"] >= limit]
+              lines.append(f"## Files >= {label} ({limit} bytes)")
+              lines.append(f"Count: {len(matched)}")
+              lines.append("")
+              if matched:
+                  lines.append("| Size (bytes) | Binary-like ext | Path |")
+                  lines.append("|---:|:---:|---|")
+                  for r in matched[:200]:
+                      lines.append(f"| {r['bytes']} | {'yes' if r['binary_extension'] else 'no'} | `{r['path']}` |")
+              else:
+                  lines.append("No tracked files at this threshold.")
+              lines.append("")
+
+          with open("large-files-report.md", "w", encoding="utf-8") as f:
+              f.write("\n".join(lines))
+          PY
+
+      - name: Run Trivy filesystem scan (non-blocking)
+        id: trivy
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@6e7ca55bfcf5676f309bc511f048ca24fd886c1b # v0.33.1
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-fs.sarif
+          severity: CRITICAL,HIGH
+          vuln-type: os,library
+          scanners: vuln,secret,misconfig
+          exit-code: '0'
+
+      - name: Create Trivy status note
+        if: always()
+        run: |
+          {
+            echo "# Trivy FS Scan Status"
+            echo
+            echo "- Result: ${{ steps.trivy.outcome }}"
+            echo "- Policy: non-blocking baseline (`exit-code: 0`)"
+            echo "- Scope: repository filesystem only"
+          } > trivy-status.md
+
+      - name: Upload artifact scan outputs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: artifact-risk-scan-results
+          path: |
+            large-files-report.md
+            large-files-top200.json
+          if-no-files-found: error
+
+      - name: Upload Trivy outputs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: trivy-fs-scan-results
+          path: |
+            trivy-fs.sarif
+            trivy-status.md
+          if-no-files-found: ignore

--- a/docs/security/artifact-and-container-adjacent-scanning.md
+++ b/docs/security/artifact-and-container-adjacent-scanning.md
@@ -1,0 +1,41 @@
+# Artifact and Container-Adjacent Scanning
+
+This repository includes a GitHub Actions workflow at:
+
+- `.github/workflows/security-artifact-container-scan.yml`
+
+## What it checks
+
+1. **Large and binary-adjacent tracked files**
+   - Enumerates tracked files via `git ls-files`.
+   - Produces a size-ranked report and marks files with binary-like extensions (for example `.deb`, `.iso`, `.zip`, `.so`).
+
+2. **Trivy filesystem scan (optional/non-blocking baseline)**
+   - Runs `trivy fs` against the repository filesystem only.
+   - Includes vulnerability, secret, and misconfiguration scanners.
+   - Scoped to local repo content only; no external systems are scanned.
+
+## Artifacts produced
+
+- `artifact-risk-scan-results`
+  - `large-files-report.md`
+  - `large-files-top200.json`
+- `trivy-fs-scan-results`
+  - `trivy-fs.sarif` (if produced)
+  - `trivy-status.md`
+
+## How to interpret results
+
+- Large-file findings are **triage signals**, not automatic failures.
+- Binary-like extension flags indicate assets that may need policy review (for provenance, licensing, and supply-chain exposure).
+- Trivy findings at this stage are **non-blocking** to establish visibility first.
+- Prioritize:
+  1. Confirm whether flagged artifacts are expected release assets.
+  2. Investigate any CRITICAL/HIGH items with clear package/file attribution.
+  3. Tighten policy later by adding blocking thresholds once false positives are understood.
+
+## Safety constraints
+
+- Do not upload secrets to artifacts.
+- The workflow scans repository contents only.
+- No external hosts or systems are scanned by this workflow.


### PR DESCRIPTION
### Motivation

- Provide lightweight, actionable visibility into repository-tracked artifacts and container-adjacent risks without changing application code or scanning external systems.
- Establish a non-blocking baseline so teams can triage findings and tune enforcement later.

### Description

- Add a GitHub Actions workflow at `.github/workflows/security-artifact-container-scan.yml` that enumerates tracked files, ranks them by size, and flags binary-like extensions to produce `large-files-report.md` and `large-files-top200.json`.
- Integrate a non-blocking Trivy filesystem scan via `aquasecurity/trivy-action` configured as a visibility baseline (`scan-type: fs`, `exit-code: 0`, `continue-on-error: true`) and output `trivy-fs.sarif` plus a `trivy-status.md` note.
- Upload scan outputs as artifacts named `artifact-risk-scan-results` (contains `large-files-report.md` and `large-files-top200.json`) and `trivy-fs-scan-results` (contains `trivy-fs.sarif` and `trivy-status.md`).
- Add documentation at `docs/security/artifact-and-container-adjacent-scanning.md` describing the checks, how to interpret results, and safety constraints (repo-only scan, do not upload secrets).

### Testing

- Ran `git diff --check` to validate patch cleanliness and it succeeded.
- Attempted automated YAML parsing via a Python+`PyYAML` check but it failed due to `PyYAML` not being installed in the validation environment, so programmatic YAML validation was not completed.
- Performed manual inspection of the newly created workflow and documentation with `sed`/`nl` to confirm the expected content and artifact names.
- The workflow is configured to run on `push`, `pull_request`, scheduled weekly, and on manual dispatch so GitHub Actions will exercise the job in CI runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7bea945e4832f8e6e647e09084399)