### PR TITLE
docs: add SECURITY_REMEDIATION_SUMMARY.md — final security regression pass

### DIFF
--- a/SECURITY_REMEDIATION_SUMMARY.md
+++ b/SECURITY_REMEDIATION_SUMMARY.md
@@ -1,0 +1,98 @@
+# Security Remediation Summary (Post-Hardening Regression Pass)
+
+Date: 2026-05-03 (UTC)
+
+## Scope and caveat
+This was a **targeted regression pass** against the requested items and available local checks. It is **not an exhaustive security audit**.
+
+## Fixed items (verified as still fixed)
+
+1. **`HUEY_API_TOKEN` enforcement remains in place**
+   - API middleware enforces bearer auth when token is configured.
+   - Non-token mode restricts privileged surfaces to local callers.
+   - Unsafe free-form task submission remains gated behind explicit `HUEY_ENABLE_UNSAFE_TASKS=true` and auth/local constraints.
+
+2. **VNC/noVNC open binding hardening remains in place**
+   - VNC startup requires `VNC_PASSWORD` and uses authenticated x11vnc.
+   - Raw VNC is loopback-bound (`-localhost`).
+   - noVNC bridge is loopback-bound (`127.0.0.1:1995`).
+   - Compose defaults publish service port to host loopback (`127.0.0.1`).
+
+3. **Dependency scan workflows exist**
+   - `security-dependency-scan.yml` (pip-audit) present and scheduled.
+   - `security-bandit.yml` present and scheduled.
+
+4. **GitHub Actions pinning appears enforced in workflows reviewed**
+   - Checked `uses:` entries in `.github/workflows/*.yml`; actions are pinned to commit SHAs.
+
+5. **No committed `:latest` Docker image tags in infra definitions reviewed**
+   - No `FROM ...:latest` or `image: ...:latest` matches in `infra/` Dockerfiles/compose YAML.
+
+## Remaining risks / notable findings
+
+1. **Local security tooling gaps in this environment**
+   - `pip-audit` and `bandit` are not installed locally, so deeper local findings were not produced by `scripts/security_check.sh`.
+
+2. **No secret scanner configuration detected**
+   - `scripts/security_check.sh` reports no `.gitleaks.toml`, `gitleaks.toml`, or `.secrets.baseline`.
+   - This weakens repeatable in-repo secret-scanning policy for local runs.
+
+3. **Potentially sensitive/sample content in non-runtime/memory datasets**
+   - Repo contains large prompt/memory datasets with token/password-like strings in text examples.
+   - No live credential was intentionally exposed in this summary; however, these corpora increase false-positive noise and should stay excluded/scoped in scanners.
+
+4. **Test suite currently not green in this environment**
+   - `pytest -q` fails at collection due to import/path/module issues and missing optional dependencies.
+   - Security regressions can be masked when baseline tests are failing.
+
+## Manual steps still required
+
+1. Install and run local security tools:
+   - `python -m pip install pip-audit bandit`
+   - Re-run `bash scripts/security_check.sh`
+
+2. Add/standardize secret scanner config for local + CI parity:
+   - Prefer `gitleaks` with committed policy file (or maintain `.secrets.baseline` workflow).
+
+3. Restore a passing baseline test collection:
+   - Resolve import/module path regressions and optional dependency strategy so security-relevant tests run reliably.
+
+4. Validate runtime deployment posture outside repo defaults:
+   - Ensure production deployments keep loopback/reverse-proxy auth/TLS pattern for API and noVNC exposure.
+
+## Recommended next PRs
+
+1. **Add first-class secret scanning policy and CI workflow hard-fail rules**
+   - Commit `gitleaks.toml` (or equivalent) with allowlists for known fixture data.
+
+2. **Add a minimal, always-runnable security smoke test job**
+   - Isolate API auth/VNC-binding checks from broader app imports so regressions are caught even if unrelated tests fail.
+
+3. **Add policy checks for forbidden docker tag patterns**
+   - Pre-commit/CI regex guard for `:latest` in runtime Docker/compose paths.
+
+4. **Stabilize pytest collection for core modules**
+   - Fix import topology around `huey.memory.PY` adapters and circular imports to re-enable security-focused tests.
+
+## Exact commands run
+
+```bash
+rg --files -g 'AGENTS.md'
+pwd && git status --short && git branch --show-current
+rg -n "password|passwd|HUEY_API_TOKEN|noVNC|VNC|:latest|latest" .github docker-compose* Dockerfile* **/* 2>/dev/null
+find . -maxdepth 3 -type f \( -name '*.yml' -o -name '*.yaml' -o -name 'Dockerfile*' -o -name 'docker-compose*.yml' -o -name '*.env*' \) | head -n 200
+rg -n "bandit|safety|pip-audit|trivy|gitleaks|secret|security" Makefile pyproject.toml requirements*.txt scripts .github/workflows 2>/dev/null
+rg -n "HUEY_API_TOKEN|Authorization|Bearer|token" src tests run.py
+rg -n "0\.0\.0\.0|--listen|localhost|-localhost|noVNC|x11vnc|websockify|5900|5901|1995" infra/docker infra -g 'Dockerfile*' -g '*.yml' -g '*.py'
+rg -n "^\s*uses:\s*[^@\s]+@" .github/workflows/*.yml
+pytest -q
+bash scripts/security_check.sh
+rg -n "image:\s*[^#\s]+:latest|FROM\s+[^\s]+:latest" infra -g '*.yml' -g 'Dockerfile*'
+rg -n "password\s*=|PASSWORD\s*=|VNC_PASSWORD|api[_-]?key|secret[_-]?key|BEGIN (RSA|OPENSSH|EC) PRIVATE KEY" src infra .github huey.env.example tests -g '!*.json' -g '!*.csv'
+nl -ba src/huey/memory/PY/api.py | sed -n '240,360p'
+nl -ba src/huey/memory/PY/env_validation.py | sed -n '1,120p'
+nl -ba .github/workflows/security-dependency-scan.yml
+nl -ba .github/workflows/security-bandit.yml
+nl -ba infra/docker/Dockerfile.vnc | sed -n '34,70p'
+nl -ba infra/docker/docker-compose.yml | sed -n '20,55p'
+```


### PR DESCRIPTION
### Motivation
- Provide a final read-only regression summary after recent hardening work that documents verified fixes, remaining risks, and reproducible commands.
- Capture an auditable record of checks for common issues (hardcoded secrets, :latest tags, HUEY_API_TOKEN enforcement, VNC/noVNC exposure, unauthenticated command submission, GitHub Actions pinning, dependency-scan presence) without changing application code.

### Description
- Add `SECURITY_REMEDIATION_SUMMARY.md` containing a concise post-hardening report that lists fixed items, remaining risks, manual follow-ups, recommended next PRs, and the exact shell commands used to produce the findings.
- The change is documentation-only; no application logic or runtime code was modified.
- The report records manual/automated checks performed (ripgrep inspections, workflow reviews, container/VNC posture checks) and references CI workflow pinning and dependency-scan workflow presence.

### Testing
- Ran `pytest -q`, which failed during collection due to import/path and optional-dependency issues, so the full test-suite could not be exercised.
- Ran `bash scripts/security_check.sh`, which completed and reported missing local tooling (`pip-audit`, `bandit`) and no secret-scanner configuration; the script executed successfully but emitted warnings.
- Performed repository scans with `rg` and inspected `.github/workflows/*` and `infra/docker` artifacts to verify action pinning, presence of dependency-scan and bandit workflows, and absence of `:latest` image tags in `infra/` definitions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7c4b09250832f8ea596c2171fdffd)