### PR TITLE
Normalize repository-control path metadata to integrations/pyhuey

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -100,9 +100,9 @@ memory/** linguist-generated=true
 # Vendored or third-party code (submodules, mirrors, etc.)
 ###############################################################################
 
-# py-gpt submodule is treated as vendored code so it does not skew language stats.
-# (Path should match the submodule path defined in .gitmodules.)
-repo/py-gpt/** linguist-vendored=true
+# PyHuey integration submodule is treated as vendored code so it does not skew language stats.
+# (Path matches the submodule path defined in .gitmodules.)
+integrations/pyhuey/** linguist-vendored=true
 
 ###############################################################################
 # Export-ignore for release tarballs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,8 +6,7 @@
 *                       @DylanLRPollock
 
 # Targeted ownership (more specific paths below)
-/src/huey/api/          @DylanLRPollock
-/src/huey/nano/         @DylanLRPollock
+/src/huey/api.py        @DylanLRPollock
 /docs/                  @DylanLRPollock
 
 # Optional extras you may want (uncomment as needed)

--- a/docs/audits/v101.1-repo-control-paths.md
+++ b/docs/audits/v101.1-repo-control-paths.md
@@ -1,0 +1,18 @@
+# v101.1 repo-control path cleanup
+
+Date: 2026-05-11
+
+## Summary of metadata-only changes
+
+- Confirmed `.gitmodules` already points at the active integration path: `integrations/pyhuey`.
+- Updated `.gitattributes` vendored-code rule from stale `repo/py-gpt/**` to `integrations/pyhuey/**` so Linguist metadata matches the real submodule location.
+- Updated `.github/CODEOWNERS` stale API directory rule from `/src/huey/api/` to the real file path `/src/huey/api.py`.
+- Removed the stale `/src/huey/nano/` CODEOWNERS rule because that directory does not exist in the repository.
+
+## Compatibility-path decision
+
+- `integrations/pygpt` does not exist in this repository at this time, so no compatibility ownership or vendored-path metadata was retained for it.
+
+## Runtime impact
+
+- No runtime Python sources were changed; this update is repository-control metadata and documentation only.


### PR DESCRIPTION
### Motivation

- Remove stale PyGPT/old-path metadata and align repository-control rules with the actual integration submodule location to avoid incorrect Linguist/vendoring and CODEOWNERS matches.
- Keep compatibility behavior explicit and documented while ensuring no runtime sources are modified.

### Description

- Replaced the vendored-code Linguist rule in `.gitattributes` from `repo/py-gpt/**` to `integrations/pyhuey/**` so vendored metadata matches the real submodule path.
- Updated `.github/CODEOWNERS` to target the real file path `/src/huey/api.py` and removed the non-existent `/src/huey/nano/` rule.
- Added `docs/audits/v101.1-repo-control-paths.md` documenting the metadata-only changes and the decision not to retain `integrations/pygpt` compatibility metadata because that path is absent.
- Confirmed `.gitmodules` already references `integrations/pyhuey` and made no source-directory renames or runtime code changes.

### Testing

- Ran a repository search with `rg` for legacy and current paths and confirmed references were updated and no stale matches remained, which succeeded.
- Verified directory existence with `test -d integrations/pygpt; test -d integrations/pyhuey; test -d repo/py-gpt` and confirmed only `integrations/pyhuey` exists (exit codes showed `integrations/pyhuey` present and the others absent).
- Inspected the metadata diff with `git diff` limited to `.gitmodules .gitattributes .github/CODEOWNERS docs/audits/v101.1-repo-control-paths.md` and committed the metadata-only changes, which completed successfully.
- Confirmed no runtime Python source files were modified during this change by restricting the diff and checks to metadata and docs, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a01e0114754832f8766b4f52f717b8d)