### PR TITLE
test(package): add CI package build/install smoke validation

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -1,0 +1,63 @@
+name: Package Smoke
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+jobs:
+  package-smoke:
+    name: Build + Install Smoke (Py3.13)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Create fresh virtual environment
+        run: python -m venv .pkg-smoke-venv
+
+      - name: Install built wheel in fresh environment
+        shell: bash
+        run: |
+          source .pkg-smoke-venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+
+      - name: Import smoke checks
+        shell: bash
+        run: |
+          source .pkg-smoke-venv/bin/activate
+          python -c "import huey"
+          python -c "import hueyos"
+          python -c "import huey.api"
+
+      - name: Console script smoke checks
+        shell: bash
+        run: |
+          source .pkg-smoke-venv/bin/activate
+          huey --help
+          huey-api --help
+
+      - name: Upload dist artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-dist-artifacts
+          path: dist/


### PR DESCRIPTION
### Motivation
- Add a focused CI smoke test to ensure the Python package can build and install cleanly from produced artifacts without publishing or requiring secrets.

### Description
- Add `.github/workflows/package-smoke.yml` that triggers on `pull_request`, `push` to `main`/`develop`, and `workflow_dispatch`.
- Use Python `3.13`, install build tooling, and run `python -m build` to produce sdist and wheel artifacts.
- Create a fresh virtual environment and install the built wheel from `dist/*.whl`, then run import smoke checks with `python -c "import huey"`, `python -c "import hueyos"`, and `python -c "import huey.api"` and run console-script smoke checks `huey --help` and `huey-api --help`.
- Upload `dist/` artifacts only on failure to aid debugging, and do not publish or consume any secrets.

### Testing
- Ran repository inspections with `rg` to verify existing workflows and `pyproject.toml` entry points which succeeded and confirmed `huey`/`huey-api` scripts and Python versions.
- Created and committed `.github/workflows/package-smoke.yml` which succeeded in the local repository changes step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a01e39343fc832f86f35ad83fcca91e)