### PR TITLE
fix(huey): replace sys.modules wrappers with explicit compatibility exports

### DIFF
--- a/src/huey/api.py
+++ b/src/huey/api.py
@@ -7,8 +7,19 @@
 
 from __future__ import annotations
 
-import sys
-
 from .memory.PY import api as _api
 
-sys.modules[__name__] = _api
+# NOTE(v101.1-migration): This module is a compatibility wrapper while
+# implementation code remains under ``src/huey/memory/PY``. Do not replace this
+# module object via ``sys.modules``; instead re-export legacy symbols explicitly.
+app = _api.app
+main = _api.main
+SCHEDULER = _api.SCHEDULER
+
+__all__ = ["app", "main", "SCHEDULER"]
+
+
+def __getattr__(name: str):
+    """Delegate unknown attributes to the legacy API module for compatibility."""
+
+    return getattr(_api, name)

--- a/src/huey/cli.py
+++ b/src/huey/cli.py
@@ -12,6 +12,8 @@ from typing import Iterable, Optional
 
 from .memory.PY import cli as _cli
 
+# NOTE(v101.1-migration): Compatibility wrapper while canonical
+# implementation remains under ``src/huey/memory/PY``.
 main = _cli.main
 
 __all__ = ["main", "parse_arguments", "run_cli", "huey_main"]

--- a/src/huey/run.py
+++ b/src/huey/run.py
@@ -7,8 +7,30 @@
 
 from __future__ import annotations
 
-import sys
-
 from .memory.PY import run as _run
 
-sys.modules[__name__] = _run
+# NOTE(v101.1-migration): Compatibility wrapper for the legacy ``huey.run``
+# module while implementation stays in ``src/huey/memory/PY``.
+main = _run.main
+run_module = _run.run_module
+minimal_run = _run.minimal_run
+run_sys_code = _run.run_sys_code
+launch_install_gui = _run.launch_install_gui
+launch_gui = _run.launch_gui
+print_pyhuey_info = _run.print_pyhuey_info
+
+__all__ = [
+    "main",
+    "run_module",
+    "minimal_run",
+    "run_sys_code",
+    "launch_install_gui",
+    "launch_gui",
+    "print_pyhuey_info",
+]
+
+
+def __getattr__(name: str):
+    """Delegate unknown attributes to the legacy runtime module."""
+
+    return getattr(_run, name)

--- a/tests/test_huey_compat_imports.py
+++ b/tests/test_huey_compat_imports.py
@@ -1,0 +1,34 @@
+"""Compatibility smoke tests for legacy ``huey`` import paths."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+
+
+def test_import_huey_api_module():
+    module = importlib.import_module("huey.api")
+    assert module.app is not None
+    assert callable(module.main)
+
+
+def test_import_huey_run_module():
+    module = importlib.import_module("huey.run")
+    assert callable(module.main)
+    assert callable(module.run_module)
+
+
+def test_import_huey_cli_module():
+    module = importlib.import_module("huey.cli")
+    assert callable(module.main)
+
+
+def test_console_script_entrypoints_resolve():
+    entry_points = importlib.metadata.entry_points(group="console_scripts")
+    mapping = {entry.name: entry for entry in entry_points}
+
+    assert "huey" in mapping
+    assert "huey-api" in mapping
+
+    assert callable(mapping["huey"].load())
+    assert callable(mapping["huey-api"].load())


### PR DESCRIPTION
### Motivation
- Reduce brittle module replacement via `sys.modules[__name__] = ...` while preserving legacy public import paths during the v101.1 migration.
- Make compatibility wrappers explicit, testable, and easier to audit without moving implementation files from `src/huey/memory/PY`.

### Description
- Replaced wholesale module substitution in `src/huey/api.py` with explicit re-exports (`app`, `main`, `SCHEDULER`) and an attribute delegation `__getattr__` to the legacy implementation module.
- Replaced wholesale module substitution in `src/huey/run.py` with explicit exported runtime entry points (`main`, `run_module`, `minimal_run`, `run_sys_code`, `launch_install_gui`, `launch_gui`, `print_pyhuey_info`) and `__getattr__` delegation.
- Added v101.1 migration compatibility comments to `src/huey/api.py`, `src/huey/run.py`, and `src/huey/cli.py` to mark these files as wrappers during migration.
- Added `tests/test_huey_compat_imports.py` to assert `import huey.api`, `import huey.run`, `import huey.cli`, and to validate console-script entry points (`huey`, `huey-api`) resolve to callables.

### Testing
- Ran `pytest -q tests/test_huey_compat_imports.py tests/test_run_entrypoint.py tests/test_huey_cli_config.py` to exercise the wrappers and entrypoint behavior.
- Test result: `8 passed, 1 skipped` and the skipped test is due to an optional `PIL.Image` dependency and is expected by existing gating.
- Verified that public imports still work and no implementation files were moved as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a01e45b4da0832fb92fde6806c02f98)