### PR TITLE
chore(namespace): add hueyos maintained scaffold

### DIFF
--- a/docs/development/v101.1-namespace-migration.md
+++ b/docs/development/v101.1-namespace-migration.md
@@ -1,0 +1,14 @@
+# v101.1 Namespace Migration Direction
+
+This document records the package namespace direction established in v101.1.
+
+- `hueyos` is the canonical distribution/package direction for maintained code.
+- `huey` remains a compatibility namespace during migration.
+- `src/huey/memory/PY` is the legacy implementation surface until code is explicitly moved.
+- No runtime behavior has changed in this scaffold task.
+
+Scope of this change:
+
+- Adds empty maintained namespace scaffolding under `src/hueyos/` for `api`, `cli`, `core`, and `runtime`.
+- Does not move implementation modules.
+- Preserves existing import compatibility behavior.

--- a/src/hueyos/api/__init__.py
+++ b/src/hueyos/api/__init__.py
@@ -1,0 +1,1 @@
+"""Maintained API namespace scaffold for :mod:`hueyos`."""

--- a/src/hueyos/cli/__init__.py
+++ b/src/hueyos/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Maintained CLI namespace scaffold for :mod:`hueyos`."""

--- a/src/hueyos/core/__init__.py
+++ b/src/hueyos/core/__init__.py
@@ -1,0 +1,1 @@
+"""Maintained core namespace scaffold for :mod:`hueyos`."""

--- a/src/hueyos/runtime/__init__.py
+++ b/src/hueyos/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Maintained runtime namespace scaffold for :mod:`hueyos`."""


### PR DESCRIPTION
### Motivation
- Provide a clean maintained namespace scaffold under `hueyos` so future development targets the canonical distribution while preserving existing `huey` compatibility and avoiding any code movement in this change.

### Description
- Added docstring-only packages `src/hueyos/api`, `src/hueyos/cli`, `src/hueyos/core`, and `src/hueyos/runtime` each containing an `__init__.py` with a short descriptive docstring.
- Added `docs/development/v101.1-namespace-migration.md` documenting that `hueyos` is the canonical distribution, `huey` remains a compatibility namespace, `src/huey/memory/PY` is the legacy implementation surface, and that no runtime behavior changed as part of this scaffold.
- Did not move or modify any implementation modules and preserved existing import compatibility behavior through the existing compatibility bridge in `src/hueyos`.

### Testing
- Ran `PYTHONPATH=src python -c "import hueyos, huey; import hueyos.api, hueyos.cli, hueyos.core, hueyos.runtime; print('ok')"` which succeeded and printed `ok`.
- Ran `python -c "import hueyos, huey; import hueyos.api, hueyos.cli, hueyos.core, hueyos.runtime; print('ok')"` without `PYTHONPATH=src` which failed with `ModuleNotFoundError` because `src` was not on the interpreter `PYTHONPATH` in that invocation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a01e6aa9b10832f94669d6aa911d388)