### PR TITLE
refactor(api): add hueyos API scaffold using legacy wrappers

### DIFF
--- a/src/hueyos/api/__init__.py
+++ b/src/hueyos/api/__init__.py
@@ -1,1 +1,5 @@
 """Maintained API namespace scaffold for :mod:`hueyos`."""
+
+from .app import SCHEDULER, app, main
+
+__all__ = ["app", "main", "SCHEDULER"]

--- a/src/hueyos/api/app.py
+++ b/src/hueyos/api/app.py
@@ -1,0 +1,21 @@
+"""Maintained ``hueyos.api`` app entrypoint with legacy compatibility.
+
+This module intentionally re-exports the existing FastAPI application from the
+legacy implementation surface while the API is being split into smaller modules.
+"""
+
+from __future__ import annotations
+
+from huey.memory.PY import api as _legacy_api
+
+app = _legacy_api.app
+main = _legacy_api.main
+SCHEDULER = _legacy_api.SCHEDULER
+
+__all__ = ["app", "main", "SCHEDULER"]
+
+
+def __getattr__(name: str):
+    """Delegate unresolved attributes to the legacy API module."""
+
+    return getattr(_legacy_api, name)

--- a/src/hueyos/api/auth.py
+++ b/src/hueyos/api/auth.py
@@ -1,0 +1,23 @@
+"""Auth and access-control helpers for the API split scaffolding.
+
+For v101.1 stabilization these functions are re-exported from the legacy API
+module so behavior remains unchanged while endpoint logic is still centralized.
+"""
+
+from __future__ import annotations
+
+from huey.memory.PY import api as _legacy_api
+
+_configured_api_token = _legacy_api._configured_api_token
+_is_local_request = _legacy_api._is_local_request
+_require_privileged_surface_access = _legacy_api._require_privileged_surface_access
+_require_unsafe_task_submission_access = _legacy_api._require_unsafe_task_submission_access
+_unsafe_task_submission_enabled = _legacy_api._unsafe_task_submission_enabled
+
+__all__ = [
+    "_configured_api_token",
+    "_is_local_request",
+    "_require_privileged_surface_access",
+    "_require_unsafe_task_submission_access",
+    "_unsafe_task_submission_enabled",
+]

--- a/src/hueyos/api/routers/__init__.py
+++ b/src/hueyos/api/routers/__init__.py
@@ -1,0 +1,10 @@
+"""Router package scaffold for the gradual ``hueyos.api`` split.
+
+Next split step:
+- Move a low-risk read-only endpoint group (for example health/system status)
+  into dedicated router modules and include them from ``hueyos.api.app``.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/tests/test_huey_compat_imports.py
+++ b/tests/test_huey_compat_imports.py
@@ -32,3 +32,12 @@ def test_console_script_entrypoints_resolve():
 
     assert callable(mapping["huey"].load())
     assert callable(mapping["huey-api"].load())
+
+
+def test_import_api_through_legacy_and_new_paths():
+    legacy = importlib.import_module("huey.api")
+    maintained = importlib.import_module("hueyos.api.app")
+
+    assert legacy.app is maintained.app
+    assert callable(legacy.main)
+    assert callable(maintained.main)


### PR DESCRIPTION
### Motivation
- Begin a safe, incremental split of the large API module by introducing a maintained `hueyos.api` namespace while preserving current behavior. 
- Provide small, low-risk entry points for future router extraction without rewriting endpoints or breaking existing imports.

### Description
- Added `src/hueyos/api/app.py` which re-exports the existing FastAPI `app`, `main`, and `SCHEDULER` from the legacy implementation at `huey.memory.PY.api` and delegates unknown attributes back to the legacy module. 
- Added `src/hueyos/api/auth.py` that re-exports the legacy auth/access helper functions (`_configured_api_token`, `_is_local_request`, `_require_privileged_surface_access`, `_require_unsafe_task_submission_access`, `_unsafe_task_submission_enabled`) so behavior remains unchanged. 
- Added router scaffold `src/hueyos/api/routers/__init__.py` with a short next-step note for moving low-risk read-only endpoints into dedicated router modules. 
- Updated `src/hueyos/api/__init__.py` to export `app`, `main`, and `SCHEDULER` from the new maintained path, and added a compatibility test in `tests/test_huey_compat_imports.py` that imports the app via both `huey.api` and `hueyos.api.app` and asserts they reference the same `app` object.

### Testing
- Ran `pytest -q tests/test_huey_compat_imports.py` which passed (`5 passed`).
- Attempted `pytest -q tests/test_huey_compat_imports.py tests/test_api_routes.py` which failed during collection due to a pre-existing vendored FastAPI stub missing `JSONResponse`, and this failure is environmental/test-harness drift not introduced by this change. 
- The new compatibility test confirms both `huey.api` and `hueyos.api.app` resolve to the same application object and that `main` remains callable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a01e93bace0832fb10e0454af5a5f22)