### PR TITLE
refactor(api): extract system health routes into dedicated router

### DIFF
--- a/src/huey/memory/PY/api.py
+++ b/src/huey/memory/PY/api.py
@@ -1268,11 +1268,9 @@ def _register_battery_hooks() -> None:
 _register_battery_hooks()
 
 
-@app.get("/healthz", tags=["System"])
-def healthz() -> Dict[str, str]:
-    """Lightweight probe used by orchestrators to ensure the API is responsive."""
+from hueyos.api.routers.system import router as system_router
 
-    return {"status": "ok", "service": "hueyos"}
+app.include_router(system_router)
 
 
 @app.post(
@@ -1349,18 +1347,6 @@ def cancel_task(task_id: str) -> TaskResponse:
             status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
         ) from exc
     return TaskResponse.from_record(record)
-
-
-@app.get(
-    "/status/system",
-    response_model=SystemStatusResponse,
-    tags=["System"],
-)
-@app.get("/system/status", response_model=SystemStatusResponse, tags=["System"])
-def system_status() -> SystemStatusResponse:
-    """Return operating system, hardware, and configuration details for HueyOS."""
-
-    return _build_system_status()
 
 
 @app.get(

--- a/src/hueyos/api/routers/system.py
+++ b/src/hueyos/api/routers/system.py
@@ -1,0 +1,29 @@
+"""System and health API routes extracted from the legacy API module."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from fastapi import APIRouter
+
+router = APIRouter(tags=["System"])
+
+
+@router.get("/healthz")
+def healthz() -> Dict[str, str]:
+    """Lightweight probe used by orchestrators to ensure the API is responsive."""
+
+    return {"status": "ok", "service": "hueyos"}
+
+
+@router.get("/status/system")
+@router.get("/system/status")
+def system_status() -> dict:
+    """Return operating system, hardware, and configuration details for HueyOS."""
+
+    from huey.memory.PY.api import _build_system_status
+
+    return _build_system_status().model_dump()
+
+
+__all__ = ["router", "healthz", "system_status"]


### PR DESCRIPTION
### Motivation
- Move the low-risk read-only health/system endpoints out of the large legacy API module to a focused router to make future incremental API splits safer while preserving existing behaviour and compatibility.

### Description
- Added `src/hueyos/api/routers/system.py` providing the `GET /healthz`, `GET /system/status`, and `GET /status/system` routes implemented on an `APIRouter` and exposing the same payloads as before.
- Wired the new router into the existing legacy FastAPI app by calling `app.include_router(system_router)` from `src/huey/memory/PY/api.py` so route paths remain unchanged.
- Removed the inline definitions of the moved endpoints from `src/huey/memory/PY/api.py` and preserved response shape by calling the legacy `_build_system_status()` and returning its serialized dict via `.model_dump()`.
- Change surface is limited to `src/hueyos/api/routers/system.py` and the include/remove edits in `src/huey/memory/PY/api.py` to keep other endpoint groups untouched.

### Testing
- Ran the scoped test command `pytest -q tests/test_api_routes.py -k 'healthz or system_status'` to validate the moved endpoints.
- Test collection failed during import with `ImportError: cannot import name 'JSONResponse' from 'fastapi.responses'`, which appears to be an existing environment/vendor mismatch and is unrelated to the router extraction.
- No moved-route tests completed due to the import failure, so moved-route behaviour should be validated once the FastAPI import issue is resolved in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a01ebc63db8832f8a0a49dddc1a8e52)