### PR TITLE
refactor(cli): scaffold hueyos command modules and move system-check

### DIFF
--- a/src/huey/memory/PY/cli.py
+++ b/src/huey/memory/PY/cli.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import shutil
 import subprocess
@@ -17,168 +16,13 @@ from importlib import import_module
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Sequence
 
+from hueyos.cli.main import build_parser
+
 __all__ = ["main"]
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="huey",
-        description="Command line interface for HueyOS runtime and utilities.",
-    )
-    sub = parser.add_subparsers(dest="command")
-    sub.required = True
-
-    init_cmd = sub.add_parser(
-        "init",
-        help="Initialise the HueyOS workspace and memory directories.",
-    )
-    init_cmd.add_argument(
-        "--verbose",
-        action="store_true",
-        help="Print the directories that were created during initialisation.",
-    )
-    init_cmd.add_argument(
-        "--run-checks",
-        action="store_true",
-        help="Run system compatibility checks after creating directories.",
-    )
-    init_cmd.set_defaults(handler=_cmd_init)
-
-    run_cmd = sub.add_parser("run", help="Launch the HueyOS runtime.")
-    run_cmd.add_argument(
-        "--cli",
-        action="store_true",
-        help="Launch the command line interface instead of the GUI.",
-    )
-    run_cmd.add_argument(
-        "--gui",
-        action="store_true",
-        help="Explicitly launch the GUI even if other flags request CLI mode.",
-    )
-    run_cmd.add_argument(
-        "--minimal",
-        action="store_true",
-        help="Use the lightweight CustomPyGPT CLI without GUI dependencies.",
-    )
-    run_cmd.add_argument(
-        "--manager-ui",
-        action="store_true",
-        help="Launch the Tkinter program manager UI instead of the main runtime.",
-    )
-    run_cmd.add_argument(
-        "--ml",
-        action="store_true",
-        help="Enable the ML optional dependency profile before launching.",
-    )
-    run_cmd.add_argument(
-        "--cloud",
-        action="store_true",
-        help="Enable the cloud optional dependency profile before launching.",
-    )
-    run_cmd.add_argument(
-        "--profile",
-        action="append",
-        default=[],
-        help="Additional runtime profiles to export via HUEY_PROFILES.",
-    )
-    run_cmd.add_argument(
-        "--skip-checks",
-        action="store_true",
-        help="Skip operating system and Python compatibility checks.",
-    )
-    run_cmd.add_argument(
-        "--no-fallback",
-        action="store_true",
-        help="Do not fall back to the CLI if the GUI fails to launch.",
-    )
-    run_cmd.set_defaults(handler=_cmd_run)
-
-    sys_cmd = sub.add_parser(
-        "system-check", help="Run environment diagnostics and compatibility checks."
-    )
-    sys_cmd.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit the collected results as JSON.",
-    )
-    sys_cmd.add_argument(
-        "--verbose",
-        action="store_true",
-        help="Always print each individual check result.",
-    )
-    sys_cmd.set_defaults(handler=_cmd_system_check)
-
-    deploy_cmd = sub.add_parser(
-        "deploy", help="Deploy HueyOS services using Docker and/or Kubernetes."
-    )
-    deploy_cmd.add_argument(
-        "--mode",
-        choices=["docker", "kubernetes", "all"],
-        default="all",
-        help="Select which deployment targets to execute.",
-    )
-    deploy_cmd.add_argument(
-        "--compose-file",
-        default="docker-compose.yml",
-        help="Path to the Docker Compose file to apply.",
-    )
-    deploy_cmd.add_argument(
-        "--manifest",
-        default="k8s.yaml",
-        help="Path to the Kubernetes manifest to apply.",
-    )
-    deploy_cmd.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Print commands without executing them.",
-    )
-    deploy_cmd.add_argument(
-        "--verbose",
-        action="store_true",
-        help="Show command output even when commands succeed.",
-    )
-    deploy_cmd.set_defaults(handler=_cmd_deploy)
-
-    agent_cmd = sub.add_parser(
-        "agent-status",
-        help="Report scheduler task counts and recent resource observations.",
-    )
-    agent_cmd.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit the status payload as JSON.",
-    )
-    agent_cmd.add_argument(
-        "--verbose",
-        action="store_true",
-        help="Include details for each tracked task in the output.",
-    )
-    agent_cmd.set_defaults(handler=_cmd_agent_status)
-
-    sort_cmd = sub.add_parser(
-        "memory-sort", help="Organise the shared memory directory by file type."
-    )
-    sort_cmd.add_argument(
-        "--source",
-        help="Source directory containing unsorted files (defaults to memory/RAW).",
-    )
-    sort_cmd.add_argument(
-        "--destination",
-        help="Destination root directory (defaults to the configured memory path).",
-    )
-    sort_cmd.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Report planned moves without modifying the filesystem.",
-    )
-    sort_cmd.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit the summary as JSON.",
-    )
-    sort_cmd.set_defaults(handler=_cmd_memory_sort)
-
-    return parser
+    return build_parser(prog="huey")
 
 
 def _cmd_init(args: argparse.Namespace) -> int:
@@ -321,24 +165,6 @@ def _cmd_run(args: argparse.Namespace) -> int:
             return 0
     except KeyboardInterrupt:  # pragma: no cover - interactive usage
         return 130
-
-
-def _cmd_system_check(args: argparse.Namespace) -> int:
-    from hueyos.system_checks import system_check
-
-    results = system_check()
-    if args.json:
-        print(json.dumps(results, indent=2, sort_keys=True))
-    else:
-        if args.verbose:
-            print("System check results:")
-        for key, value in sorted(results.items()):
-            status = "OK" if value else "WARN"
-            if args.verbose:
-                print(f"  {key}: {status}")
-            else:
-                print(f"{key}: {status}")
-    return 0
 
 
 def _run_command(

--- a/src/hueyos/cli/commands/__init__.py
+++ b/src/hueyos/cli/commands/__init__.py
@@ -1,0 +1,11 @@
+"""Command registration helpers for the maintained HueyOS CLI."""
+
+from .memory import register_memory_commands
+from .runtime import register_runtime_commands
+from .system import register_system_commands
+
+__all__ = [
+    "register_memory_commands",
+    "register_runtime_commands",
+    "register_system_commands",
+]

--- a/src/hueyos/cli/commands/memory.py
+++ b/src/hueyos/cli/commands/memory.py
@@ -1,0 +1,42 @@
+"""Memory command registration scaffold for incremental CLI extraction."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Callable
+
+
+def _legacy_handler(name: str) -> Callable[[argparse.Namespace], int]:
+    def _handler(args: argparse.Namespace) -> int:
+        from huey.memory.PY import cli as legacy_cli
+
+        return getattr(legacy_cli, name)(args)
+
+    return _handler
+
+
+def register_memory_commands(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register memory-oriented command groups via legacy handlers."""
+
+    sort_cmd = subparsers.add_parser(
+        "memory-sort", help="Organise the shared memory directory by file type."
+    )
+    sort_cmd.add_argument(
+        "--source",
+        help="Source directory containing unsorted files (defaults to memory/RAW).",
+    )
+    sort_cmd.add_argument(
+        "--destination",
+        help="Destination root directory (defaults to the configured memory path).",
+    )
+    sort_cmd.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report planned moves without modifying the filesystem.",
+    )
+    sort_cmd.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the summary as JSON.",
+    )
+    sort_cmd.set_defaults(handler=_legacy_handler("_cmd_memory_sort"))

--- a/src/hueyos/cli/commands/runtime.py
+++ b/src/hueyos/cli/commands/runtime.py
@@ -1,0 +1,63 @@
+"""Runtime command registration scaffold for incremental CLI extraction."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Callable
+
+
+def _legacy_handler(name: str) -> Callable[[argparse.Namespace], int]:
+    def _handler(args: argparse.Namespace) -> int:
+        from huey.memory.PY import cli as legacy_cli
+
+        return getattr(legacy_cli, name)(args)
+
+    return _handler
+
+
+def register_runtime_commands(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register runtime and utility commands via legacy handlers."""
+
+    init_cmd = subparsers.add_parser(
+        "init",
+        help="Initialise the HueyOS workspace and memory directories.",
+    )
+    init_cmd.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print the directories that were created during initialisation.",
+    )
+    init_cmd.add_argument(
+        "--run-checks",
+        action="store_true",
+        help="Run system compatibility checks after creating directories.",
+    )
+    init_cmd.set_defaults(handler=_legacy_handler("_cmd_init"))
+
+    run_cmd = subparsers.add_parser("run", help="Launch the HueyOS runtime.")
+    run_cmd.add_argument("--cli", action="store_true", help="Launch the command line interface instead of the GUI.")
+    run_cmd.add_argument("--gui", action="store_true", help="Explicitly launch the GUI even if other flags request CLI mode.")
+    run_cmd.add_argument("--minimal", action="store_true", help="Use the lightweight CustomPyGPT CLI without GUI dependencies.")
+    run_cmd.add_argument("--manager-ui", action="store_true", help="Launch the Tkinter program manager UI instead of the main runtime.")
+    run_cmd.add_argument("--ml", action="store_true", help="Enable the ML optional dependency profile before launching.")
+    run_cmd.add_argument("--cloud", action="store_true", help="Enable the cloud optional dependency profile before launching.")
+    run_cmd.add_argument("--profile", action="append", default=[], help="Additional runtime profiles to export via HUEY_PROFILES.")
+    run_cmd.add_argument("--skip-checks", action="store_true", help="Skip operating system and Python compatibility checks.")
+    run_cmd.add_argument("--no-fallback", action="store_true", help="Do not fall back to the CLI if the GUI fails to launch.")
+    run_cmd.set_defaults(handler=_legacy_handler("_cmd_run"))
+
+    deploy_cmd = subparsers.add_parser("deploy", help="Deploy HueyOS services using Docker and/or Kubernetes.")
+    deploy_cmd.add_argument("--mode", choices=["docker", "kubernetes", "all"], default="all", help="Select which deployment targets to execute.")
+    deploy_cmd.add_argument("--compose-file", default="docker-compose.yml", help="Path to the Docker Compose file to apply.")
+    deploy_cmd.add_argument("--manifest", default="k8s.yaml", help="Path to the Kubernetes manifest to apply.")
+    deploy_cmd.add_argument("--dry-run", action="store_true", help="Print commands without executing them.")
+    deploy_cmd.add_argument("--verbose", action="store_true", help="Show command output even when commands succeed.")
+    deploy_cmd.set_defaults(handler=_legacy_handler("_cmd_deploy"))
+
+    agent_cmd = subparsers.add_parser(
+        "agent-status",
+        help="Report scheduler task counts and recent resource observations.",
+    )
+    agent_cmd.add_argument("--json", action="store_true", help="Emit the status payload as JSON.")
+    agent_cmd.add_argument("--verbose", action="store_true", help="Include details for each tracked task in the output.")
+    agent_cmd.set_defaults(handler=_legacy_handler("_cmd_agent_status"))

--- a/src/hueyos/cli/commands/system.py
+++ b/src/hueyos/cli/commands/system.py
@@ -1,0 +1,43 @@
+"""System-focused command registrations for the HueyOS CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def _cmd_system_check(args: argparse.Namespace) -> int:
+    from hueyos.system_checks import system_check
+
+    results = system_check()
+    if args.json:
+        print(json.dumps(results, indent=2, sort_keys=True))
+    else:
+        if args.verbose:
+            print("System check results:")
+        for key, value in sorted(results.items()):
+            status = "OK" if value else "WARN"
+            if args.verbose:
+                print(f"  {key}: {status}")
+            else:
+                print(f"{key}: {status}")
+    return 0
+
+
+def register_system_commands(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register system inspection commands."""
+
+    sys_cmd = subparsers.add_parser(
+        "system-check", help="Run environment diagnostics and compatibility checks."
+    )
+    sys_cmd.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the collected results as JSON.",
+    )
+    sys_cmd.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Always print each individual check result.",
+    )
+    sys_cmd.set_defaults(handler=_cmd_system_check)

--- a/src/hueyos/cli/main.py
+++ b/src/hueyos/cli/main.py
@@ -1,0 +1,28 @@
+"""Shared CLI builders for the maintained :mod:`hueyos` namespace."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Callable
+
+from .commands import register_memory_commands, register_runtime_commands, register_system_commands
+
+
+ParserHandler = Callable[[argparse.Namespace], int]
+
+
+def build_parser(*, prog: str = "huey") -> argparse.ArgumentParser:
+    """Build the Huey CLI parser while delegating command wiring by domain."""
+
+    parser = argparse.ArgumentParser(
+        prog=prog,
+        description="Command line interface for HueyOS runtime and utilities.",
+    )
+    sub = parser.add_subparsers(dest="command")
+    sub.required = True
+
+    register_runtime_commands(sub)
+    register_system_commands(sub)
+    register_memory_commands(sub)
+
+    return parser

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
 from huey import cli
+from huey.memory.PY import cli as legacy_cli
 
 
 def test_system_check_json(monkeypatch, capsys):
@@ -31,6 +32,22 @@ def test_system_check_json(monkeypatch, capsys):
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
     assert payload == {"os_supported": True, "python_supported": True}
+
+
+def test_direct_legacy_cli_module_invocation_system_check(monkeypatch, capsys):
+    def fake_system_check() -> Dict[str, bool]:
+        return {"os_supported": True, "python_supported": True}
+
+    monkeypatch.setattr(
+        "hueyos.system_checks.system_check", fake_system_check, raising=True
+    )
+
+    exit_code = legacy_cli.main(["system-check", "--json"])
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "os_supported": True,
+        "python_supported": True,
+    }
 
 
 def test_memory_sort_dry_run(tmp_path: Path, capsys):

--- a/tests/test_huey_compat_imports.py
+++ b/tests/test_huey_compat_imports.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import importlib.metadata
+import json
 
 
 def test_import_huey_api_module():
@@ -32,6 +33,23 @@ def test_console_script_entrypoints_resolve():
 
     assert callable(mapping["huey"].load())
     assert callable(mapping["huey-api"].load())
+
+
+def test_huey_console_script_executes_system_check(monkeypatch, capsys):
+    def fake_system_check():
+        return {"os_supported": True, "python_supported": True}
+
+    monkeypatch.setattr("hueyos.system_checks.system_check", fake_system_check)
+    entry_points = importlib.metadata.entry_points(group="console_scripts")
+    mapping = {entry.name: entry for entry in entry_points}
+
+    runner = mapping["huey"].load()
+    exit_code = runner(["system-check", "--json"])
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "os_supported": True,
+        "python_supported": True,
+    }
 
 
 def test_import_api_through_legacy_and_new_paths():


### PR DESCRIPTION
### Motivation
- Begin incremental extraction of the large legacy CLI into a maintained `hueyos` namespace while keeping the legacy `huey` entrypoint functional.
- Move a single low-risk command (`system-check`) first to validate the extraction pattern and test compatibility.

### Description
- Added a new CLI scaffold `src/hueyos/cli/main.py` that builds the parser and delegates command registration to domain modules.
- Created command modules `src/hueyos/cli/commands/__init__.py`, `system.py`, `memory.py`, and `runtime.py` and moved `system-check` handler into `commands/system.py`.
- Kept runtime- and memory-related commands wired via safe legacy handler wrappers in `commands/runtime.py` and `commands/memory.py` to call into `huey.memory.PY.cli` until they are migrated.
- Updated the legacy CLI at `src/huey/memory/PY/cli.py` to reuse the new `hueyos` parser builder so the existing `huey` console script and module-level invocation remain compatible.
- Added/updated tests to assert console script resolution and execution and direct legacy-module invocation still work with the moved command.

### Testing
- Ran the unit tests with `python -m pytest -q tests/test_cli.py tests/test_huey_compat_imports.py` and all tests passed (`12 passed`).
- New/updated tests include a console-entrypoint smoke test that executes `system-check` via the `huey` entrypoint and a direct legacy-module invocation test for `huey.memory.PY.cli.main(...)`, both of which succeeded.
- Existing CLI behavior (command names and flags) is preserved by the legacy wrappers and was validated by the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a01ee60066c832f81c179832283f72f)