### PR TITLE
test(runtime): add CI-safe V1 proof loop harness and tests

### DIFF
--- a/src/hueyos/runtime/v1_loop.py
+++ b/src/hueyos/runtime/v1_loop.py
@@ -1,0 +1,82 @@
+"""CI-safe V1 proof-loop orchestration.
+
+V1 target:
+controlled MP3 fixture -> local transcription -> cognition bridge -> structured log
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from time import perf_counter
+from uuid import uuid4
+
+
+def _to_iso8601_utc(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def run_v1_loop(
+    source_fixture_path: str | Path,
+    transcribe_func,
+    cognition_func,
+    log_writer,
+) -> dict:
+    """Run the CI-safe V1 orchestration with injected dependencies.
+
+    The function never calls real external APIs/models itself; all behavior is
+    delegated to injected callables.
+    """
+    start_dt = datetime.now(tz=UTC)
+    start_perf = perf_counter()
+    source_file = str(source_fixture_path)
+
+    run_record = {
+        "run_id": str(uuid4()),
+        "timestamp_start": _to_iso8601_utc(start_dt),
+        "timestamp_end": None,
+        "source_file": source_file,
+        "transcription_engine": None,
+        "transcription_model": None,
+        "transcript": None,
+        "cognition_provider": None,
+        "cognition_model": None,
+        "response": None,
+        "runtime_seconds": None,
+        "exit_status": "error",
+        "error_message_if_any": None,
+    }
+
+    try:
+        transcription_result = transcribe_func(source_file)
+        if isinstance(transcription_result, dict):
+            run_record["transcription_engine"] = transcription_result.get(
+                "transcription_engine"
+            )
+            run_record["transcription_model"] = transcription_result.get(
+                "transcription_model"
+            )
+            run_record["transcript"] = transcription_result.get("transcript")
+        else:
+            run_record["transcript"] = str(transcription_result)
+
+        cognition_result = cognition_func(run_record["transcript"])
+        if isinstance(cognition_result, dict):
+            run_record["cognition_provider"] = cognition_result.get(
+                "cognition_provider"
+            )
+            run_record["cognition_model"] = cognition_result.get("cognition_model")
+            run_record["response"] = cognition_result.get("response")
+        else:
+            run_record["response"] = str(cognition_result)
+
+        run_record["exit_status"] = "success"
+    except (OSError, ValueError, TypeError, RuntimeError) as exc:
+        run_record["error_message_if_any"] = str(exc)
+
+    end_dt = datetime.now(tz=UTC)
+    run_record["timestamp_end"] = _to_iso8601_utc(end_dt)
+    run_record["runtime_seconds"] = round(perf_counter() - start_perf, 6)
+
+    log_writer(run_record)
+    return run_record

--- a/tests/test_v1_loop.py
+++ b/tests/test_v1_loop.py
@@ -1,0 +1,90 @@
+import json
+from pathlib import Path
+
+from hueyos.runtime.v1_loop import run_v1_loop
+
+
+REQUIRED_FIELDS = {
+    "run_id",
+    "timestamp_start",
+    "timestamp_end",
+    "source_file",
+    "transcription_engine",
+    "transcription_model",
+    "transcript",
+    "cognition_provider",
+    "cognition_model",
+    "response",
+    "runtime_seconds",
+    "exit_status",
+    "error_message_if_any",
+}
+
+
+def test_v1_loop_writes_json_record(tmp_path: Path):
+    fixture = tmp_path / "fixture.mp3"
+    fixture.write_bytes(b"fake-mp3-content")
+
+    json_log = tmp_path / "run.json"
+
+    def fake_transcribe(source_file: str):
+        assert source_file.endswith("fixture.mp3")
+        return {
+            "transcription_engine": "local-mock",
+            "transcription_model": "mock-whisper-small",
+            "transcript": "hello from fixture",
+        }
+
+    def fake_cognition(transcript: str):
+        assert transcript == "hello from fixture"
+        return {
+            "cognition_provider": "bridge-mock",
+            "cognition_model": "mock-cognition-v1",
+            "response": {"intent": "ack", "text": "received"},
+        }
+
+    def write_json(record: dict):
+        json_log.write_text(json.dumps(record), encoding="utf-8")
+
+    record = run_v1_loop(fixture, fake_transcribe, fake_cognition, write_json)
+
+    assert set(record.keys()) == REQUIRED_FIELDS
+    assert record["source_file"] == str(fixture)
+    assert record["exit_status"] == "success"
+
+    persisted = json.loads(json_log.read_text(encoding="utf-8"))
+    assert persisted == record
+
+
+def test_v1_loop_writes_jsonl_record(tmp_path: Path):
+    fixture = tmp_path / "fixture.mp3"
+    fixture.write_bytes(b"fake-mp3-content")
+
+    jsonl_log = tmp_path / "runs.jsonl"
+
+    def fake_transcribe(_source_file: str):
+        return {
+            "transcription_engine": "local-mock",
+            "transcription_model": "mock-whisper-small",
+            "transcript": "sample transcript",
+        }
+
+    def fake_cognition(_transcript: str):
+        return {
+            "cognition_provider": "bridge-mock",
+            "cognition_model": "mock-cognition-v1",
+            "response": "mock response",
+        }
+
+    def append_jsonl(record: dict):
+        with jsonl_log.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+
+    run_v1_loop(fixture, fake_transcribe, fake_cognition, append_jsonl)
+
+    lines = jsonl_log.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    persisted = json.loads(lines[0])
+    assert set(persisted.keys()) == REQUIRED_FIELDS
+    assert persisted["transcript"] == "sample transcript"
+    assert persisted["response"] == "mock response"


### PR DESCRIPTION
### Motivation
- Provide a small, CI-safe harness that exercises the advertised V1 proof loop: controlled MP3 fixture → local transcription → cognition bridge → structured log.
- Ensure CI tests do not call real Whisper/OpenAI/local models by using dependency injection for transcription, cognition, and log writing.
- Capture a deterministic run record shape that can be validated by automated tests.

### Description
- Add `src/hueyos/runtime/v1_loop.py` which implements `run_v1_loop(source_fixture_path, transcribe_func, cognition_func, log_writer)` and returns/writes a structured run record.
- The run record includes the required fields: `run_id`, `timestamp_start`, `timestamp_end`, `source_file`, `transcription_engine`, `transcription_model`, `transcript`, `cognition_provider`, `cognition_model`, `response`, `runtime_seconds`, `exit_status`, and `error_message_if_any`.
- `run_v1_loop` measures runtime, accepts both dict or string returns from injected callables, sets `exit_status`/`error_message_if_any` on exceptions, and delegates persistence to the injected `log_writer`.
- Add tests in `tests/test_v1_loop.py` that use fake MP3 fixtures and fake `transcribe`/`cognition` functions to validate JSON and JSONL logging paths.

### Testing
- Ran `pytest -q tests/test_v1_loop.py` which executed the new tests and both tests passed (2 passed).
- Tests validate that a fake MP3 file is accepted, the injected fakes populate the record fields, and the written JSON/JSONL files match the returned run record.
- No network, model, or external API calls are made during the tests due to dependency injection of `transcribe_func` and `cognition_func`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0227af0a18832f91f71398848a2918)