### PR TITLE
feat(cli): add CI-safe v1-run mock command with structured logs

### DIFF
--- a/src/huey/memory/PY/cli.py
+++ b/src/huey/memory/PY/cli.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import shutil
 import subprocess
@@ -321,6 +322,49 @@ def _cmd_memory_sort(args: argparse.Namespace) -> int:
             print(f"Skipped {len(summary['skipped'])} file(s):")
             for item in summary["skipped"]:
                 print(f"  - {item}")
+    return 0
+
+
+def _cmd_v1_run(args: argparse.Namespace) -> int:
+    from hueyos.runtime.v1_loop import run_v1_loop
+
+    if not args.mock:
+        raise RuntimeError(
+            "Real transcription/cognition providers are disabled by default. "
+            "Use --mock or explicitly wire configured providers."
+        )
+
+    source_file = Path(args.audio_file).expanduser().resolve()
+    if not source_file.exists():
+        raise RuntimeError(f"Audio fixture not found: {source_file}")
+
+    log_dir = Path(args.log_dir).expanduser().resolve() if args.log_dir else Path("runs").resolve()
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "v1-run.jsonl"
+
+    def _mock_transcribe(_source_file: str) -> dict[str, str]:
+        return {
+            "transcription_engine": "mock-transcriber",
+            "transcription_model": "mock-whisper-v1",
+            "transcript": "mock transcript from fixture",
+        }
+
+    def _mock_cognition(transcript: str) -> dict[str, Any]:
+        return {
+            "cognition_provider": "mock-cognition",
+            "cognition_model": "mock-cognition-v1",
+            "response": {
+                "status": "ok",
+                "summary": f"processed {len(transcript)} chars",
+            },
+        }
+
+    def _append_jsonl(record: dict[str, Any]) -> None:
+        with log_path.open("a", encoding="utf-8") as file_obj:
+            file_obj.write(json.dumps(record, sort_keys=True) + "\n")
+
+    record = run_v1_loop(source_file, _mock_transcribe, _mock_cognition, _append_jsonl)
+    print(json.dumps({"log_file": str(log_path), "run_id": record["run_id"]}, sort_keys=True))
     return 0
 
 

--- a/src/hueyos/cli/commands/runtime.py
+++ b/src/hueyos/cli/commands/runtime.py
@@ -61,3 +61,20 @@ def register_runtime_commands(subparsers: argparse._SubParsersAction[argparse.Ar
     agent_cmd.add_argument("--json", action="store_true", help="Emit the status payload as JSON.")
     agent_cmd.add_argument("--verbose", action="store_true", help="Include details for each tracked task in the output.")
     agent_cmd.set_defaults(handler=_legacy_handler("_cmd_agent_status"))
+
+    v1_run_cmd = subparsers.add_parser(
+        "v1-run",
+        help="Run the CI-safe V1 proof loop against an audio fixture.",
+    )
+    v1_run_cmd.add_argument("audio_file", help="Path to the audio fixture (for example fixture.mp3).")
+    v1_run_cmd.add_argument(
+        "--mock",
+        action="store_true",
+        help="Use fake transcription/cognition providers (CI-safe default path).",
+    )
+    v1_run_cmd.add_argument(
+        "--log-dir",
+        default=None,
+        help="Directory for run artifacts. Defaults to ./runs.",
+    )
+    v1_run_cmd.set_defaults(handler=_legacy_handler("_cmd_v1_run"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -176,3 +176,38 @@ def test_deploy_dry_run_prints_expected_commands(tmp_path: Path, monkeypatch, ca
     captured = capsys.readouterr().out.splitlines()
     assert any(line.startswith("[dry-run] docker compose -f") for line in captured)
     assert any(line.startswith("[dry-run] kubectl apply -f") for line in captured)
+
+
+def test_v1_run_mock_writes_structured_log(tmp_path: Path, capsys):
+    fixture = tmp_path / "fixture.mp3"
+    fixture.write_bytes(b"fake-mp3")
+    log_dir = tmp_path / "logs"
+
+    exit_code = cli.main(["v1-run", str(fixture), "--mock", "--log-dir", str(log_dir)])
+
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    log_file = Path(output["log_file"])
+    assert log_file.exists()
+    lines = log_file.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+
+    record = json.loads(lines[0])
+    required = {
+        "run_id",
+        "timestamp_start",
+        "timestamp_end",
+        "source_file",
+        "transcription_engine",
+        "transcription_model",
+        "transcript",
+        "cognition_provider",
+        "cognition_model",
+        "response",
+        "runtime_seconds",
+        "exit_status",
+        "error_message_if_any",
+    }
+    assert required.issubset(record.keys())
+    assert record["source_file"] == str(fixture.resolve())
+    assert record["exit_status"] == "success"


### PR DESCRIPTION
### Motivation
- Provide a safe, CI-friendly CLI entrypoint for the V1 proof-loop scaffold that runs against a controlled audio fixture and emits a structured run artifact without calling real transcription or cognition providers.
- Ensure the default behavior blocks real API/model calls and writes logs to a user-configurable safe location so CI can validate end-to-end flow deterministically.

### Description
- Register a new `v1-run` subcommand in `src/hueyos/cli/commands/runtime.py` with positional `audio_file` and flags `--mock` and `--log-dir` wired to the legacy handler bridge via `_legacy_handler("_cmd_v1_run")`.
- Implement `_cmd_v1_run` in `src/huey/memory/PY/cli.py` which requires `--mock`, validates the fixture path, creates the `--log-dir` or defaults to `./runs`, and writes JSONL records to `v1-run.jsonl` using the injected `run_v1_loop` scaffold with mock `transcribe` and `cognition` callables.
- Emit a short JSON summary to stdout containing `run_id` and `log_file` after the run completes.
- Add a test `tests/test_cli.py::test_v1_run_mock_writes_structured_log` that invokes `cli.main(["v1-run", <fixture>, "--mock", "--log-dir", <dir>])` and asserts the log file exists and contains the required JSON fields.

### Testing
- Ran `pytest -q tests/test_cli.py::test_v1_run_mock_writes_structured_log tests/test_v1_loop.py` and both tests passed.
- Verified additional local test run showed `3 passed` for the targeted tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a022a542e64832fbd8618e1f2e48bf7)