### PR TITLE
fix(docker): align runtime to hueyos and launch `huey-api` (remove `pygpt` drift)

### DIFF
--- a/docs/audits/v101.1-docker-alignment.md
+++ b/docs/audits/v101.1-docker-alignment.md
@@ -1,0 +1,56 @@
+# v101.1 Docker Alignment Audit
+
+## Scope
+Align the main HueyOS Docker runtime with the repository package (`hueyos`) and remove PyGPT as the primary runtime.
+
+## Build
+From the repository root:
+
+```bash
+docker compose -f infra/docker/docker-compose.yml build
+```
+
+Optional build with explicit extras:
+
+```bash
+HUEY_BUILD_EXTRAS=ml,data,cloud docker compose -f infra/docker/docker-compose.yml build
+```
+
+## Run
+Start API service:
+
+```bash
+docker compose -f infra/docker/docker-compose.yml up -d api
+```
+
+Run worker profile:
+
+```bash
+docker compose -f infra/docker/docker-compose.yml --profile worker up -d worker
+```
+
+## Health Check
+Container health uses:
+
+- `GET http://127.0.0.1:1995/healthz`
+
+Host check example:
+
+```bash
+curl -fsS http://127.0.0.1:1995/healthz
+```
+
+## Validation Commands
+
+```bash
+docker compose -f infra/docker/docker-compose.yml config
+```
+
+```bash
+docker compose -f infra/docker/docker-compose.yml ps
+```
+
+## Outcome
+- Main runtime image installs this repository from `pyproject.toml`.
+- Runtime entrypoint is `huey-api` (HueyOS API), not `pygpt`.
+- Container runs as non-root user `hueyos`.

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -1,14 +1,15 @@
-ARG PYTHON_VERSION=3.13.5-bookworm
+ARG PYTHON_VERSION=3.13-bookworm
 FROM python:${PYTHON_VERSION}
 
+ARG HUEY_EXTRAS=""
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    # build tooling for pip packages with C extensions (like PyAudio)
     build-essential pkg-config \
-    # needed for PyAudio build: provides portaudio.h
     portaudio19-dev \
-    # optional but helps with audio backends on Linux
     libasound2-dev libasound2 libasound2-data libasound2-plugins \
-    # Qt / X11 runtime deps (PySide)
     ca-certificates \
     libglib2.0-0 libdbus-1-3 libnss3 \
     libx11-6 libx11-xcb1 libxkbcommon-x11-0 \
@@ -19,13 +20,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgl1 libegl1 \
  && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --no-cache-dir --upgrade pip \
- && pip install --no-cache-dir pygpt-net==2.0.154
+WORKDIR /app
 
-# (optional) run as non-root at runtime
-RUN useradd -m -u 1000 pygpt && mkdir -p /data && chown -R pygpt:pygpt /data
-USER pygpt
+COPY pyproject.toml README.md /app/
+COPY src /app/src
 
-ENV QT_X11_NO_MITSHM=1
-ENTRYPOINT ["pygpt"]
-CMD ["--workdir=/data"]
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel \
+ && if [ -n "$HUEY_EXTRAS" ]; then \
+      pip install --no-cache-dir ".[${HUEY_EXTRAS}]"; \
+    else \
+      pip install --no-cache-dir .; \
+    fi
+
+RUN useradd -m -u 1000 hueyos \
+ && chown -R hueyos:hueyos /app
+
+USER hueyos
+
+EXPOSE 1995
+
+ENTRYPOINT ["huey-api"]

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -23,6 +23,7 @@ services:
         HUEY_EXTRAS: ${HUEY_BUILD_EXTRAS:-ml,data,cloud}
     image: ${HUEY_IMAGE:-hueyos:0.1.0}
     container_name: ${HUEY_API_CONTAINER:-hueyos-api}
+    command: ["huey-api"]
     env_file:
       - ${HUEY_ENV_FILE:-huey.env.example}
     environment:


### PR DESCRIPTION
### Motivation
- The Compose topology describes a `hueyos` runtime but the Dockerfile installed and launched `pygpt-net`, creating runtime drift that must be corrected.
- Make the main image install this repository as the canonical `hueyos` package instead of installing `pygpt-net` as the primary runtime.
- Use the repository-supported Python baseline (`3.13`) and ensure reproducible installs via project metadata rather than ad-hoc pip installs.
- Enforce a non-root runtime user and keep the container API surface aligned with Compose healthchecks and ports.

### Description
- Replaced the Dockerfile pip install of `pygpt-net` with building/installing the repository from `pyproject.toml` + `src/` and added an optional build arg `HUEY_EXTRAS` to install extras via `pip install ".[${HUEY_EXTRAS}]"`.
- Set the base Python arg to `3.13-bookworm`, added `PYTHONDONTWRITEBYTECODE`/`PYTHONUNBUFFERED`, and preserved required OS packages for audio/X11 where present.
- Created a non-root user `hueyos` (UID 1000), ensured `/app` ownership, switched to `USER hueyos`, exposed port `1995`, and changed the image entrypoint to `huey-api`.
- Updated `infra/docker/docker-compose.yml` to explicitly run `command: ["huey-api"]` for the `api` service and to pass the `HUEY_EXTRAS` build arg; retained the `healthcheck` that hits `/healthz` on `1995`.
- Added `docs/audits/v101.1-docker-alignment.md` describing `build`, `run`, `health` and `validation` commands and the intent that the main runtime is `hueyos` (not `pygpt`).

### Testing
- Attempted to validate the Compose configuration with `docker compose -f infra/docker/docker-compose.yml config`, but the `docker` CLI was not available in this environment so the check could not be executed (failure due to missing `docker` binary).
- Verified file-level changes and content edits locally by inspecting `infra/docker/Dockerfile`, `infra/docker/docker-compose.yml`, and `docs/audits/v101.1-docker-alignment.md` to ensure the new entrypoint, user, install path, build args, and health endpoint are present (inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a022affdb88832f9ae3891afc45e260)