### PR TITLE
fix(docker): separate optional PyHuey cockpit image from HueyOS runtime

### DIFF
--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -50,6 +50,19 @@ services:
       retries: 5
       start_period: 10s
 
+
+  pyhuey-cockpit:
+    <<: *service_defaults
+    build:
+      context: .
+      dockerfile: pyhuey/Dockerfile
+    image: ${PYHUEY_IMAGE:-pyhuey-cockpit:0.1.0}
+    container_name: ${PYHUEY_CONTAINER:-pyhuey-cockpit}
+    command: ["--workdir=/data"]
+    volumes:
+      - ./pyhuey-data:/data
+    profiles: ["cockpit"]
+
   worker:
     <<: *service_defaults
     image: ${HUEY_IMAGE:-hueyos:0.1.0}

--- a/infra/docker/pyhuey/Dockerfile
+++ b/infra/docker/pyhuey/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.12-bookworm
+
+# Optional PyHuey cockpit/tooling image derived from upstream PyGPT runtime.
+# This image is intentionally separate from the HueyOS runtime image.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libglib2.0-0 libdbus-1-3 libnss3 \
+    libx11-6 libx11-xcb1 libxkbcommon-x11-0 \
+    libxext6 libxi6 libxrender1 \
+    libxcb1 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
+    libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-shm0 libxcb-sync1 \
+    libxcb-xfixes0 libxcb-xinerama0 \
+    libgl1 libegl1 \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -u 1000 pyhuey
+USER pyhuey
+ENV HOME=/home/pyhuey \
+    QT_X11_NO_MITSHM=1
+
+# Preserve upstream provenance/compatibility by installing upstream package.
+RUN python -m pip install --no-cache-dir --upgrade pip \
+ && pip install --no-cache-dir pygpt-net
+
+WORKDIR /workspace
+
+# Keep upstream entrypoint for compatibility; PyHuey identity is documented as
+# project-controlled cockpit/tooling integration surface.
+ENTRYPOINT ["pygpt"]
+CMD ["--workdir=/data"]

--- a/infra/docker/pyhuey/README.md
+++ b/infra/docker/pyhuey/README.md
@@ -1,0 +1,18 @@
+# PyHuey optional cockpit image
+
+This directory defines an **optional PyHuey cockpit/tooling container image** for
+Monkey-Head-Project. It is intentionally separate from the HueyOS runtime image.
+
+## Scope boundary
+
+- **HueyOS runtime**: `infra/docker/Dockerfile` (runs `huey-api`).
+- **PyHuey cockpit/tooling**: `infra/docker/pyhuey/Dockerfile` (derived from
+  upstream `pygpt-net` for provenance and compatibility).
+
+PyHuey is a project-controlled cockpit/tooling integration surface and **not**
+the Huey Brain V1 runtime boundary.
+
+## Provenance
+
+PyHuey cockpit packaging here preserves upstream PyGPT provenance by installing
+`pygpt-net` and retaining the upstream `pygpt` entrypoint for compatibility.


### PR DESCRIPTION
### Motivation

- Keep the PyHuey cockpit/tooling image separate from the HueyOS runtime to avoid mixing cockpit packaging with the Huey Brain runtime.
- Make the cockpit image explicitly optional and clearly delimited in the repo and Compose configuration.
- Preserve upstream PyGPT provenance for PyHuey by installing `pygpt-net` and retaining the upstream `pygpt` entrypoint.
- Ensure Compose and runtime paths for HueyOS do not implicitly depend on or include the cockpit image.

### Description

- Added an optional PyHuey cockpit image at `infra/docker/pyhuey/Dockerfile` that installs upstream `pygpt-net` and keeps the `pygpt` entrypoint for provenance and compatibility.
- Added `infra/docker/pyhuey/README.md` documenting the scope boundary and clarifying that PyHuey is cockpit/tooling, not the Huey Brain runtime.
- Updated `infra/docker/docker-compose.yml` to include a `pyhuey-cockpit` service under a `cockpit` profile and mounted data volume `./pyhuey-data:/data`.
- Ensured the new `pyhuey-cockpit` service is optional (profile `cockpit`) and does not appear as a dependency of the `api` or `worker` HueyOS runtime services.

### Testing

- Ran `git status --short` to confirm working-tree changes were present and staged as expected (succeeded).
- Committed the changes with message `fix(docker): separate optional pyhuey cockpit image` (commit created successfully).
- Attempted `docker compose -f infra/docker/docker-compose.yml config` to validate Compose configuration but it failed because the Docker CLI is not available in this environment (`/bin/bash: line 1: docker: command not found`).
- No further automated tests (CI/lint) were executed in this environment; CI should validate the Compose file and build the optional `pyhuey-cockpit` image under the `cockpit` profile in pipeline runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a022bbae39c832f8f964de3b8543513)