### PR TITLE
chore(pyhuey): add pyhuey console script alias and phase-1 identity audit (preserve pygpt compatibility)

### DIFF
--- a/docs/audits/v101.1-pyhuey-identity-phase1.md
+++ b/docs/audits/v101.1-pyhuey-identity-phase1.md
@@ -1,0 +1,26 @@
+# v101.1 PyHuey Identity Phase 1 Audit
+
+Date: 2026-05-11  
+Scope: `vendor/pygpt/py-gpt` compatibility stub
+
+## What changed
+
+1. Added `pyhuey` console script alias while retaining `pygpt`.
+2. Kept published package metadata name as `pygpt-net` for compatibility.
+3. Updated description to reflect PyHuey cockpit fork identity without claiming a distinct published package.
+4. Added project URLs for Monkey-Head-Project/PyHuey and upstream PyGPT provenance.
+5. Updated local README language to preserve upstream attribution and explain compatibility intent.
+
+## Upstream-compatible guarantees still in place
+
+- `pygpt-net` package name remains unchanged in metadata.
+- `pygpt` console script remains available.
+- `pyhuey` points to the same runtime entrypoint as `pygpt`.
+- Upstream PyGPT origin is explicitly cited in README and project URLs.
+- No Python package/module renames were performed.
+
+## Deferred / out of scope for phase 1
+
+- Full upstream `py-gpt` submodule checkout in `integrations/pyhuey` (currently not populated here).
+- GUI/runtime feature parity with upstream PyGPT.
+- Packaging or publishing a separate `pyhuey` distribution.

--- a/vendor/pygpt/py-gpt/README.md
+++ b/vendor/pygpt/py-gpt/README.md
@@ -1,5 +1,11 @@
-# Py-GPT vendor placeholder
+# PyHuey / PyGPT vendor placeholder
 
-This directory emulates the upstream [`py-gpt`](https://github.com/szczyglis-dev/py-gpt) submodule used by Monkey Head. It contains a lightweight stub of the `pygpt_net` package so the project can run and test without fetching the full upstream repository.
+This directory emulates the upstream [`py-gpt`](https://github.com/szczyglis-dev/py-gpt) submodule used by Monkey Head. It contains a lightweight `pygpt_net` compatibility stub used during the PyHuey cockpit identity migration, so the project can run and test without fetching the full upstream repository.
+
+## Compatibility and identity notes
+
+- Upstream package identity and compatibility are preserved via the `pygpt-net` project name and `pygpt` console script.
+- A `pyhuey` console script is also exposed, mapped to the same entrypoint as `pygpt`.
+- This stub preserves PyGPT provenance; it is not presented as a separate published `pyhuey` package.
 
 If you need the full implementation, replace this directory with the real submodule checkout or install `pygpt-net` from PyPI.

--- a/vendor/pygpt/py-gpt/pyproject.toml
+++ b/vendor/pygpt/py-gpt/pyproject.toml
@@ -5,7 +5,17 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pygpt-net"
 version = "0.0.0-local"
-description = "Stub vendor of the py-gpt project for Monkey Head development"
+description = "PyHuey cockpit fork compatibility stub derived from upstream PyGPT (published package name remains pygpt-net)."
 authors = [{name = "Monkey Head Team"}]
 readme = "README.md"
 requires-python = ">=3.11"
+
+[project.urls]
+Homepage = "https://github.com/DylanLRPollock/Monkey-Head-Project"
+Repository = "https://github.com/DylanLRPollock/Monkey-Head-Project"
+"PyHuey Cockpit" = "https://github.com/DylanLRPollock/Monkey-Head-Project/tree/main/integrations/pyhuey"
+"Upstream PyGPT" = "https://github.com/szczyglis-dev/py-gpt"
+
+[project.scripts]
+pygpt = "pygpt_net:main"
+pyhuey = "pygpt_net:main"

--- a/vendor/pygpt/py-gpt/src/pygpt_net/__init__.py
+++ b/vendor/pygpt/py-gpt/src/pygpt_net/__init__.py
@@ -20,7 +20,7 @@ import os
 from pathlib import Path
 from typing import Final
 
-__all__ = ["__version__"]
+__all__ = ["__version__", "main"]
 
 __version__ = "2.6.67"
 
@@ -61,3 +61,10 @@ def _ensure_private_nltk_data() -> None:
 
 
 _ensure_private_nltk_data()
+
+
+def main() -> int:
+    """Compatibility CLI entrypoint for pygpt/pyhuey console scripts."""
+
+    print("pygpt-net vendor stub is installed (Monkey-Head-Project / PyHuey compatibility mode).")
+    return 0


### PR DESCRIPTION
### Motivation
- Introduce a PyHuey cockpit identity surface without breaking upstream PyGPT compatibility or claiming a separate published package.
- Provide a compatibility CLI alias so operators can run `pyhuey` while preserving the existing `pygpt` entrypoint and provenance.
- Record the changes and remaining work in a short audit so the phase-1 migration is explicit and reviewable.

### Description
- Added `pygpt` and `pyhuey` console scripts in the vendored stub metadata that both map to the same runtime entrypoint `pygpt_net:main` to preserve compatibility and provide the new alias (file: `vendor/pygpt/py-gpt/pyproject.toml`).
- Implemented a lightweight `main()` CLI in the vendored package so both scripts resolve to a concrete command (`vendor/pygpt/py-gpt/src/pygpt_net/__init__.py`).
- Updated the vendored README to document PyHuey cockpit identity while explicitly preserving upstream PyGPT attribution and the published project name `pygpt-net` (`vendor/pygpt/py-gpt/README.md`).
- Added an audit document `docs/audits/v101.1-pyhuey-identity-phase1.md` explaining what remains upstream-compatible and what is deferred in Phase 1.

### Testing
- Ran repository inspections (`rg`, `sed`, `find`) to verify targets and updated files; these commands completed successfully.
- Verified the modified vendored files are syntactically valid and committed them to the branch successfully.
- Attempted `python -m build vendor/pygpt/py-gpt -o /tmp/pyhuey-build`, which failed in the current environment due to a missing `build` module (`No module named build`).
- Result summary: metadata and code changes applied and committed; CLI alias is present in package metadata and entrypoint; packaging/build step could not be executed in this environment due to missing tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a022cfa35bc832f95db650605c142a6)