### PR TITLE
chore(pyhuey): update user-facing branding strings to PyHuey (preserve pygpt compatibility)

### DIFF
--- a/docs/audits/v101.1-pyhuey-branding-string-audit.md
+++ b/docs/audits/v101.1-pyhuey-branding-string-audit.md
@@ -1,0 +1,31 @@
+# v101.1 PyHuey Branding String Audit
+
+Date: 2026-05-11  
+Scope: user-facing PyHuey branding pass without package/module renames.
+
+## Commands
+
+- `rg -n "PyGPT|pygpt" src/huey/memory/PY src/hueyos/cli/commands/runtime.py README.md`
+
+## Classification of remaining `PyGPT` / `pygpt` strings
+
+### 1) Upstream provenance (keep)
+
+- `README.md` references to **PyGPT-net** in architecture posture sections as lineage/deferred aperture context.
+- `src/huey/memory/PY/pygpt_integration.py` docstrings describing PyHuey as forked from PyGPT/PyGPT-net.
+
+### 2) Package compatibility (keep for now)
+
+- `pygpt_net` import/module references across runtime and integration code paths.
+- `config/pygpt_net/config.json` paths in installer/config helper modules.
+- CLI version output text: `pygpt_net version: ...` in `src/huey/memory/PY/run.py`.
+
+### 3) Still needs migration (future pass)
+
+- Additional user-facing references in optional installer scripts and legacy/deferred docs that still print "PyGPT/PyGPT-net" where PyHuey wording may be more appropriate.
+- Vendored/compatibility tree wording under legacy `pygpt_*` filenames that should be reviewed only when import compatibility is formally migrated.
+
+## Outcome
+
+- Updated immediate user-facing cockpit strings in maintained CLI/runtime entrypoints to say **PyHuey**.
+- Preserved provenance and package compatibility references to avoid breaking imports.

--- a/src/huey/memory/PY/pygpt_custom_cli.py
+++ b/src/huey/memory/PY/pygpt_custom_cli.py
@@ -3,7 +3,7 @@
 # www.dlrp.ca
 # HueyOS: Pygpt Custom Cli module (huey)
 
-"""Lightweight CLI integration mimicking the legacy PyGPT launcher."""
+"""Lightweight CLI integration mimicking the legacy PyHuey launcher."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from .pygpt_memory import Memory
 
 
 class CustomPyGPT:
-    """A minimal chatbot used when full PyGPT dependencies are unavailable."""
+    """A minimal chatbot used when full PyHuey dependencies are unavailable."""
 
     def __init__(self, prompt_file: str | Path | None = None):
         if prompt_file is None:
@@ -53,7 +53,7 @@ class CustomPyGPT:
     def run_cli(self) -> None:
         """Run an interactive CLI loop suitable for simple testing."""
 
-        print("Custom PyGPT CLI. Type 'exit' to quit.")
+        print("Custom PyHuey CLI. Type 'exit' to quit.")
         user_prompt = input(
             "Enter main prompt or press Enter to use default:\n"
             f"{self.main_prompt}\n> "

--- a/src/huey/memory/PY/run.py
+++ b/src/huey/memory/PY/run.py
@@ -3,7 +3,7 @@
 # www.dlrp.ca
 # HueyOS: Run module (huey)
 
-"""Runtime entry points integrating the PyGPT stack with Monkey Head."""
+"""Runtime entry points integrating the PyHuey stack with Monkey Head."""
 
 from __future__ import annotations
 
@@ -67,7 +67,7 @@ def _prepare_pygpt(source: str | None = None) -> bool:
 
 
 def _load_cli(source: str | None = None) -> Callable[..., None]:
-    """Import and return the canonical PyGPT CLI runner.
+    """Import and return the canonical PyHuey CLI runner.
 
     Falls back to :func:`minimal_run` if the CLI cannot be imported due to
     missing dependencies.
@@ -84,14 +84,14 @@ def _load_cli(source: str | None = None) -> Callable[..., None]:
 
 
 def launch_cli(*args, source: str | None = None, **kwargs) -> None:
-    """Launch the PyGPT CLI entry point if available."""
+    """Launch the PyHuey CLI entry point if available."""
 
     cli_run = _load_cli(source)
     cli_run(*args, **kwargs)
 
 
 def launch_gui(source: str | None = None) -> None:
-    """Start the PyGPT GUI with the Monkey Head manager tool enabled."""
+    """Start the PyHuey GUI with the Monkey Head manager tool enabled."""
 
     if not _prepare_pygpt(source):
         raise RuntimeError("pygpt_net package is not available")
@@ -158,7 +158,7 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--minimal",
         action="store_true",
-        help="Run lightweight CustomPyGPT CLI",
+        help="Run lightweight CustomPyHuey CLI",
     )
     parser.add_argument(
         "--simple-chat",

--- a/tests/test_custom_pygpt_cli.py
+++ b/tests/test_custom_pygpt_cli.py
@@ -40,5 +40,6 @@ def test_run_cli_records_chat_messages(monkeypatch, capsys):
         {"role": "assistant", "content": "Echo: hello"},
     ]
     output = capsys.readouterr().out
+    assert "Custom PyHuey CLI. Type 'exit' to quit." in output
     assert "Available PDFs:" in output
     assert "- manual.pdf" in output


### PR DESCRIPTION
### Motivation

- Start the user-facing PyHuey identity migration in cockpit/CLI surfaces while avoiding any package or import renames.  
- Ensure upstream PyGPT provenance and compatibility with existing `pygpt_net` imports remain intact.  
- Make a small, reviewable change that can be tested and iterated on for further migration passes.

### Description

- Replaced visible user-facing strings from “PyGPT” to “PyHuey” in the maintained CLI/runtime entrypoints at `src/huey/memory/PY/pygpt_custom_cli.py` and `src/huey/memory/PY/run.py`.  
- Updated the unit test `tests/test_custom_pygpt_cli.py` to assert the new startup banner (`Custom PyHuey CLI. Type 'exit' to quit.`).  
- Added a short branding audit report at `docs/audits/v101.1-pyhuey-branding-string-audit.md` classifying remaining `PyGPT/pygpt` occurrences as upstream provenance, package compatibility, or future migration work.  
- Preserved all `pygpt_net` package/module names, compatibility wrappers, and import paths and did not rename any Python package directories.

### Testing

- Ran the focused test suite with `pytest -q tests/test_custom_pygpt_cli.py tests/test_run_minimal.py` which completed successfully (`5 passed`).  
- Performed a targeted search with `rg -n "PyGPT|pygpt" src/huey/memory/PY src/hueyos/cli/commands/runtime.py README.md` to populate the audit and verify remaining occurrences.  
- Added the audit document summarizing remaining `PyGPT/pygpt` strings and the intended future migration categories.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a02311f79b0832f83009ce4e29e6a00)