### PR TITLE
docs(deps): document patched Redis wheel overlay and replace absolute Windows path

### DIFF
--- a/docs/development/patched-wheels.md
+++ b/docs/development/patched-wheels.md
@@ -1,0 +1,42 @@
+# Patched wheels policy (PyHuey Redis overlay)
+
+This document defines how to use and audit locally patched wheels without making normal installs depend on local machine paths.
+
+## Scope
+
+- `requirements.txt` remains the portable baseline install for the repository.
+- Patched wheel overlays are optional and must be explicitly applied.
+- No absolute local user path (for example `C:\\Users\\...`) may be required for standard installs.
+
+## Current wheelhouse entry
+
+| Field | Value |
+|---|---|
+| Wheel filename | `llama_index_vector_stores_redis-0.8.0-py3-none-any.whl` |
+| SHA256 hash | `2a09961603a50f9148b4632e6d40abb23b990f35df0f530f33a7c710625cf31a` |
+| Source version | `llama-index-vector-stores-redis==0.8.0` |
+| Patch reason | Temporary Redis vector-store compatibility overlay for PyHuey Windows cockpit environment. |
+| Wheel path in repo | `platform/windows/huey/pyhuey/patched-wheels/` |
+| Install command | `python -m pip install "llama-index-vector-stores-redis @ ./platform/windows/huey/pyhuey/patched-wheels/llama_index_vector_stores_redis-0.8.0-py3-none-any.whl#sha256=2a09961603a50f9148b4632e6d40abb23b990f35df0f530f33a7c710625cf31a"` |
+| Rollback path | `python -m pip uninstall -y llama-index-vector-stores-redis && python -m pip install "llama-index-vector-stores-redis==0.8.0"` |
+
+## Validation note (`pip check`)
+
+After applying either:
+
+- baseline install (`python -m pip install -r requirements.txt`), or
+- the optional patched wheel overlay,
+
+run:
+
+```bash
+python -m pip check
+```
+
+Expected outcome is:
+
+```text
+No broken requirements found.
+```
+
+If `pip check` fails after overlay install, remove the overlay via the rollback path above and re-run `python -m pip check`.

--- a/platform/windows/huey/pyhuey/requirements-known-good-with-redis-freeze.txt
+++ b/platform/windows/huey/pyhuey/requirements-known-good-with-redis-freeze.txt
@@ -167,7 +167,7 @@ llama-index-vector-stores-chroma==0.5.5
 llama-index-vector-stores-elasticsearch==0.5.1
 llama-index-vector-stores-pinecone==0.7.1
 llama-index-vector-stores-qdrant==0.8.8
-llama-index-vector-stores-redis @ file:///C:/Users/admin/Desktop/HueyOS/Build/PyGPT/RedisPatch/wheel-out/llama_index_vector_stores_redis-0.8.0-py3-none-any.whl#sha256=2a09961603a50f9148b4632e6d40abb23b990f35df0f530f33a7c710625cf31a
+llama-index-vector-stores-redis @ ./patched-wheels/llama_index_vector_stores_redis-0.8.0-py3-none-any.whl#sha256=2a09961603a50f9148b4632e6d40abb23b990f35df0f530f33a7c710625cf31a
 llama-index-workflows==2.14.0
 llama-parse==0.6.54
 lxml==6.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@
 # - constraints.txt carries shared anchor pins used by editable installs and extras.
 # - Platform-specific markers remain inline where needed.
 # - pavucontrol remains a Debian/system package, not a pip dependency.
+# - Patched wheel overlays (for example Redis vector-store compatibility) are optional and documented in docs/development/patched-wheels.md.
 # - The attached known-good environment reported: "No broken requirements found."
 #
 # Source basis for this refresh:


### PR DESCRIPTION
### Motivation

- Prevent requirement installs from depending on an absolute, local Windows user path and make patched wheel usage explicit and auditable. 
- Keep `requirements.txt` as the portable baseline while supporting an optional patched wheel overlay for a Redis vector-store compatibility case.

### Description

- Added `docs/development/patched-wheels.md` describing the wheelhouse policy for the Redis overlay and including wheel metadata, install/rollback commands, patch reason, and `pip check` guidance. 
- Replaced the absolute Windows local wheel reference in `platform/windows/huey/pyhuey/requirements-known-good-with-redis-freeze.txt` with a repo-relative path: `llama-index-vector-stores-redis @ ./patched-wheels/llama_index_vector_stores_redis-0.8.0-py3-none-any.whl#sha256=2a09961603a50f9148b4632e6d40abb23b990f35df0f530f33a7c710625cf31a`.
- Updated top-level `requirements.txt` to note that patched wheel overlays are optional and documented in `docs/development/patched-wheels.md`; preserved all pinned versions (no upgrades).
- Documented the wheel entry: wheel filename `llama_index_vector_stores_redis-0.8.0-py3-none-any.whl`, SHA256 `2a09961603a50f9148b4632e6d40abb23b990f35df0f530f33a7c710625cf31a`, and example install/rollback commands (`python -m pip install "llama-index-vector-stores-redis @ ./platform/windows/huey/pyhuey/patched-wheels/...whl#sha256=..."` and the corresponding uninstall/restore command).

### Testing

- Ran `python -m pip check` after the changes and it returned `No broken requirements found.` (success).
- No pinned dependency versions were changed and no unit tests were modified; existing test suite is unaffected by these documentation and path adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0232211b9c832f9fa2db69f5c83736)