### PR TITLE
security(tools): narrow subprocess exception handling

### DIFF
--- a/infra/docker/docker/orchestrator_utils.py
+++ b/infra/docker/docker/orchestrator_utils.py
@@ -132,8 +132,13 @@ def ensure_system_requirements(
             if proc.returncode == 0:
                 logger.info("Internet connectivity verified via %s", host)
                 break
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.debug("Ping to %s failed: %s", host, exc)
+        except (
+            OSError,
+            ValueError,
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+        ) as exc:  # pragma: no cover - defensive
+            logger.warning("Ping to %s failed: %s", host, exc)
     else:
         raise RuntimeError(
             "Internet connectivity check failed (ping targets exhausted)."
@@ -193,8 +198,13 @@ def enable_services(logger: logging.Logger) -> None:
 
     try:
         run(["sudo", "usermod", "-aG", "docker", os.getlogin()], logger, check=False)
-    except Exception:  # pragma: no cover - best-effort
-        logger.debug("Unable to add current user to docker group.")
+    except (
+        OSError,
+        ValueError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+    ) as exc:  # pragma: no cover - best-effort
+        logger.warning("Unable to add current user to docker group: %s", exc)
 
 
 def _detect_cpu_flags() -> set[str]:

--- a/tests/test_hostos_module.py
+++ b/tests/test_hostos_module.py
@@ -56,3 +56,30 @@ def test_configure_firewall():
         ),
     ):
         configure_firewall(1234)
+
+
+def test_enable_services_logs_usermod_failure(caplog):
+    with (
+        patch("orchestrator_utils.shutil.which", return_value=True),
+        patch(
+            "orchestrator_utils.run",
+            side_effect=[DummyCompleted(), OSError("no login")],
+        ),
+        caplog.at_level("WARNING"),
+    ):
+        enable_services()
+    assert "Unable to add current user to docker group" in caplog.text
+
+
+def test_system_requirements_ping_failure_then_success(caplog):
+    with (
+        patch("orchestrator_utils.shutil.disk_usage") as mock_usage,
+        patch("orchestrator_utils.run") as mock_run,
+        caplog.at_level("WARNING"),
+    ):
+        mock_usage.return_value = type("U", (), {"free": 10 * (1024**3)})()
+        mock_run.side_effect = [OSError("ping missing"), DummyCompleted(returncode=0)]
+
+        HostOS.ensure_system_requirements(logger=HostOS.log, ping_hosts=("a", "b"))
+
+    assert "Ping to a failed" in caplog.text


### PR DESCRIPTION
### Motivation
- Eliminate silent, broad `except Exception` handlers around subprocess/shell execution to reduce security noise and satisfy Bandit guidance. 
- Preserve best-effort/non-fatal behavior while making failures visible in logs for diagnostics.

### Description
- Replace broad `except Exception` in `infra/docker/docker/orchestrator_utils.py` with explicit exceptions: `OSError`, `ValueError`, `subprocess.CalledProcessError`, and `subprocess.TimeoutExpired` in the ping loop inside `ensure_system_requirements` and around the `usermod` call in `enable_services`.
- Change debug-only suppression to visible warnings using lazy logging (e.g. `logger.warning("Ping to %s failed: %s", host, exc)`).
- Preserve existing control flow so ping probing continues to the next host and `usermod` failures remain best-effort/non-fatal.
- Add two unit tests in `tests/test_hostos_module.py` that validate logging for the failure paths: `test_enable_services_logs_usermod_failure` and `test_system_requirements_ping_failure_then_success`.

### Testing
- Ran `pytest -q tests/test_hostos_module.py` which executed the modified and new tests; result: `5 passed`.
- The added tests assert that failures are logged (warning level) and that fallback behavior proceeds as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a02351e2118832fb9071037e5d0cb21)