### PR TITLE
security(storage): log and narrow legacy file mutation errors

### DIFF
--- a/src/huey/memory/PY/storage_management.py
+++ b/src/huey/memory/PY/storage_management.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import time
@@ -22,6 +23,8 @@ from pathlib import Path
 from typing import Iterable, List, Optional
 
 __all__ = ["StorageManager"]
+
+logger = logging.getLogger(__name__)
 
 # Default subfolders maintained inside the memory directory
 DEFAULT_FOLDERS: List[str] = [
@@ -113,8 +116,8 @@ class StorageManager:
             if p.is_file():
                 try:
                     total += p.stat().st_size
-                except OSError:
-                    pass
+                except (FileNotFoundError, PermissionError) as exc:
+                    logger.warning("Failed to stat file for size calculation: %s (%s)", p, exc)
         return total
 
     # -----------------------------------------------------
@@ -126,12 +129,27 @@ class StorageManager:
         threshold = time.time() - days * 86400
         removed = 0
         for p in path.rglob("*"):
-            if p.is_file() and p.stat().st_mtime < threshold:
+            try:
+                is_file = p.is_file()
+            except OSError as exc:
+                logger.warning("Failed to inspect path while pruning old files: %s (%s)", p, exc)
+                continue
+
+            if not is_file:
+                continue
+
+            try:
+                modified_time = p.stat().st_mtime
+            except (FileNotFoundError, PermissionError) as exc:
+                logger.warning("Failed to stat file while pruning old files: %s (%s)", p, exc)
+                continue
+
+            if modified_time < threshold:
                 try:
                     p.unlink()
                     removed += 1
-                except OSError:
-                    pass
+                except (FileNotFoundError, PermissionError) as exc:
+                    logger.warning("Failed to delete old file: %s (%s)", p, exc)
         self.cleanup_empty_dirs()
         return removed
 

--- a/tests/test_legacy_storage_management.py
+++ b/tests/test_legacy_storage_management.py
@@ -1,0 +1,36 @@
+import os
+import time
+from pathlib import Path
+
+from huey.memory.PY.storage_management import StorageManager
+
+
+def test_remove_older_than_logs_delete_failures(tmp_path, monkeypatch, caplog):
+    base = tmp_path / "memory"
+    base.mkdir()
+    stale = base / "stale.txt"
+    stale.write_text("data", encoding="utf-8")
+
+    old_time = time.time() - 10 * 86400
+    os.utime(stale, (old_time, old_time))
+
+    original_unlink = Path.unlink
+
+    def fail_unlink(self: Path, *args, **kwargs):
+        if self.name == "stale.txt":
+            raise PermissionError("blocked")
+        return original_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_unlink)
+
+    mgr = StorageManager(base)
+    caplog.set_level("WARNING")
+
+    removed = mgr.remove_older_than(7)
+
+    assert removed == 0
+    assert stale.exists()
+    assert any(
+        "Failed to delete old file" in rec.message and "stale.txt" in rec.message
+        for rec in caplog.records
+    )


### PR DESCRIPTION
### Motivation
- Fix dangerous broad exception swallowing around filesystem mutation in the legacy storage manager so failures are not silently ignored. 
- Harden prune/size paths that perform `stat`, `is_file`, and `unlink` operations to improve observability and reduce security-sensitive blindspots. 
- Ensure logs include only path context and exception messages and never secret file contents.

### Description
- Added a module `logger` and replaced broad `OSError`/silent `except` handlers in `src/huey/memory/PY/storage_management.py` with operation-specific handling (`FileNotFoundError`, `PermissionError`, and targeted `OSError` for path inspection) and warning logs that include the file `Path` and exception text. 
- For `get_total_size` the `stat()` error path now logs a warning with the `Path` and exception instead of silently passing. 
- For `remove_older_than` the code now separately guards `is_file` inspection, `stat()` for `st_mtime`, and `unlink()` calls with specific exception handling and logs, and continues processing other files on failure. 
- Added `tests/test_legacy_storage_management.py` which monkeypatches `Path.unlink` to raise `PermissionError` for a target file and asserts the prune operation logs the deletion failure and does not count the file as removed.

### Testing
- Ran the focused test command: `pytest -q tests/test_legacy_storage_management.py tests/test_storage_management.py`. 
- Result: all tests passed (`4 passed`). 
- The new test verifies that a failed `unlink()` is logged and not silently swallowed, and existing behavior covered by `tests/test_storage_management.py` remains green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a02362bdc68832f9fffe0c7f99b00ae)