### PR TITLE
fix(gui): replace silent ttk theme fallback with debug logging

### DIFF
--- a/src/huey/memory/PY/ai_tools_gui.py
+++ b/src/huey/memory/PY/ai_tools_gui.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
 
@@ -47,6 +48,8 @@ from huey.memory.PY.llm import LLMAdapter, LLMProvider
 from huey.utils.paths import ensure_subdirectory, get_memory_path
 
 from .config_manager import ConfigManager
+
+logger = logging.getLogger(__name__)
 
 
 def _format_bytes(size: float | int | None) -> str:
@@ -156,10 +159,18 @@ def run_ai_tools() -> None:
     root.configure(bg=DARK_BG)
 
     style = ttk.Style(root)
+    style_errors: tuple[type[BaseException], ...] = (
+        RuntimeError,
+        AttributeError,
+        ValueError,
+        TypeError,
+    )
+    if tk is not None and hasattr(tk, "TclError"):
+        style_errors = (*style_errors, tk.TclError)
     try:
         style.theme_use("clam")
-    except Exception:
-        pass
+    except style_errors as exc:
+        logger.debug("Unable to apply ttk theme 'clam': %s", exc)
     style.configure("TNotebook", background=DARK_BG)
     style.configure("TNotebook.Tab", background=ACCENT_PURPLE, foreground=LIGHT_FG)
     style.map(


### PR DESCRIPTION
### Motivation
- Avoid a silent `except Exception: pass` around optional GUI theme application so cosmetic/style failures are observable while keeping them non-fatal and avoiding `NameError` risk when `tkinter` may be absent.

### Description
- Added module logging (`logger = logging.getLogger(__name__)`) and replaced the broad catch around `ttk.Style.theme_use("clam")` with a narrowed `style_errors` tuple (`RuntimeError`, `AttributeError`, `ValueError`, `TypeError`) and conditionally included `tk.TclError` when `tk` is present, then logged failures with lazy formatting at debug level instead of swallowing them.

### Testing
- Verified the targeted files for the silent `except` pattern and compiled the updated module with `python -m py_compile src/huey/memory/PY/ai_tools_gui.py`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a02620c9094832f8605e28e64663cf9)