### PR TITLE
test(package): add release dry-run workflow for artifact validation

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,70 @@
+name: Release Dry Run
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "pyproject.toml"
+      - "setup.py"
+      - "setup.cfg"
+      - "MANIFEST.in"
+      - "requirements*.txt"
+      - "src/**"
+      - ".github/workflows/release-dry-run.yml"
+
+jobs:
+  release-dry-run:
+    name: Build + Install Validation (Py3.13)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Generate SHA256 checksums
+        run: sha256sum dist/* > dist/SHA256SUMS
+
+      - name: Create fresh virtual environment
+        run: python -m venv .release-dry-run-venv
+
+      - name: Install built wheel in fresh environment
+        shell: bash
+        run: |
+          source .release-dry-run-venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+
+      - name: Import smoke checks
+        shell: bash
+        run: |
+          source .release-dry-run-venv/bin/activate
+          python -c "import huey"
+          python -c "import hueyos"
+          python -c "import huey.api"
+
+      - name: Console script smoke checks
+        shell: bash
+        run: |
+          source .release-dry-run-venv/bin/activate
+          huey --help
+          huey-api --help
+
+      - name: Upload release dry run artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dry-run-dist
+          path: dist/
+          if-no-files-found: error


### PR DESCRIPTION
### Motivation
- Provide a safe release validation workflow that builds distribution artifacts and verifies installability without publishing to PyPI or GitHub Releases.
- Ensure release artifacts include verifiable checksums and that console entrypoints and package imports work in a clean environment.

### Description
- Add `.github/workflows/release-dry-run.yml` which triggers on `workflow_dispatch` and on `pull_request` when release-relevant files change.
- Build sdist and wheel with `python -m build` and generate `dist/SHA256SUMS` using `sha256sum` for all artifacts.
- Create a fresh virtual environment, install the built wheel from `dist/*.whl`, run import smoke checks (`huey`, `hueyos`, `huey.api`) and console script smoke checks (`huey --help`, `huey-api --help`).
- Upload the `dist/` directory (including checksums) as a workflow artifact and deliberately omit any publishing/push-to-PyPI or release steps so no secrets are required.

### Testing
- No automated test suite was executed within this change because the commit only adds a workflow file and GitHub Actions has not yet run it for this branch.
- The new workflow will perform build/install/smoke tests when executed on GitHub Actions via `workflow_dispatch` or when a PR modifies release files, and will surface pass/fail in the Actions run logs.
- The repository's existing package smoke workflows remain available for additional validation and can be used alongside the new dry-run workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0264110370832fa8d42199bc0b8658)