### PR TITLE
chore(repo): add low-noise drift checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
+      - name: Run drift checker
+        run: make check-drift
+
       - name: Run linters
         run: make lint
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PORT ?= 1995
 APP ?= huey.api:app
 PKG_COV ?= --cov=huey --cov=hueyos
 
-.PHONY: help setup install install-dev precommit-install format lint test coverage run run-reload health
+.PHONY: help setup install install-dev precommit-install format lint check-drift test coverage run run-reload health
 
 help:
 	@echo "Common targets:"
@@ -20,7 +20,8 @@ help:
 	@echo "  make install-dev      - install developer extras with constraints"
 	@echo "  make precommit-install- install git hooks"
 	@echo "  make format           - run black + isort"
-	@echo "  make lint             - run black/isort/ruff/flake8"
+	@echo "  make lint             - run drift checks + black/isort/ruff/flake8"
+	@echo "  make check-drift      - run repository drift checker"
 	@echo "  make test             - run pytest"
 	@echo "  make coverage         - run pytest with coverage for huey + hueyos"
 	@echo "  make run              - run FastAPI app via uvicorn"
@@ -45,10 +46,14 @@ format:
 
 lint:
 	$(PYTHON) scripts/check_stale_platform_strings.py
+	$(PYTHON) scripts/check_repo_drift.py
 	black --check src tests conftest.py
 	isort --check-only src tests conftest.py
 	ruff check src tests conftest.py
 	flake8 src tests conftest.py
+
+check-drift:
+	$(PYTHON) scripts/check_repo_drift.py
 
 test:
 	$(PYTHON) -m pytest -q

--- a/scripts/check_repo_drift.py
+++ b/scripts/check_repo_drift.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Check for newly-added repository drift strings in current-facing content."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class DriftRule:
+    name: str
+    pattern: re.Pattern[str]
+    message: str
+    strict: bool = True
+
+
+STRICT_CURRENT_FACING_PREFIXES: tuple[str, ...] = (
+    "README",
+    "docs/",
+    ".github/",
+    "infra/",
+    "platform/",
+    "scripts/",
+    "Makefile",
+    "Dockerfile",
+)
+
+NON_CURRENT_FACING_PREFIXES: tuple[str, ...] = (
+    "archive/",
+    "archives/",
+    "docs/archive/",
+    "docs/archives/",
+    "docs/audits/",
+    "docs/provenance/",
+    "provenance/",
+    "vendor/",
+    "tests/fixtures/",
+)
+
+NON_CURRENT_FACING_NAMES: tuple[str, ...] = (
+    "CHANGELOG.md",
+    "LICENSE",
+    "scripts/check_repo_drift.py",
+)
+
+
+def _is_pyhuey_canonical() -> bool:
+    return os.path.isdir("integrations/pyhuey")
+
+
+RULES: list[DriftRule] = [
+    DriftRule(
+        name="repo-py-gpt-path",
+        pattern=re.compile(r"\brepo/py-gpt\b"),
+        message="Replace stale path 'repo/py-gpt' with current pathing (for example integrations/pyhuey).",
+    ),
+    DriftRule(
+        name="windows-hueybody-path",
+        pattern=re.compile(r"\bplatform/windows/hueybody\b"),
+        message="Use platform/windows/huey for cockpit/build paths.",
+    ),
+    DriftRule(
+        name="huey-core-label",
+        pattern=re.compile(r"\bHuey Core\b"),
+        message="Use 'Huey Body' for current-facing docs, keeping Huey Core only for archive/provenance contexts.",
+    ),
+    DriftRule(
+        name="docker-primary-pygpt",
+        pattern=re.compile(r"\b(pygpt|pygpt-net)\b", re.IGNORECASE),
+        message="Do not present PyGPT as the primary runtime in main Dockerfiles; use hueyos/HueyOS runtime entrypoints.",
+    ),
+]
+
+
+def run_git(*args: str) -> str:
+    return subprocess.check_output(["git", *args], text=True).strip()
+
+
+def resolve_base_ref(explicit_base: str | None) -> str:
+    if explicit_base:
+        return explicit_base
+
+    base_ref = os.getenv("GITHUB_BASE_REF")
+    if base_ref:
+        candidate = f"origin/{base_ref}"
+        try:
+            run_git("rev-parse", "--verify", candidate)
+            return run_git("merge-base", "HEAD", candidate)
+        except subprocess.CalledProcessError:
+            pass
+
+    try:
+        return run_git("rev-parse", "HEAD~1")
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError("Unable to determine a diff base. Pass --base explicitly.") from exc
+
+
+def iter_added_lines(base_ref: str) -> Iterable[tuple[str, str, int]]:
+    diff = run_git("diff", "--unified=0", "--no-color", f"{base_ref}...HEAD", "--")
+
+    current_file: str | None = None
+    current_line = 0
+
+    for raw_line in diff.splitlines():
+        if raw_line.startswith("+++ b/"):
+            current_file = raw_line[6:]
+            continue
+
+        if raw_line.startswith("@@"):
+            plus_segment = raw_line.split("+", 1)[1].split(" ", 1)[0]
+            line_token = plus_segment.split(",", 1)[0]
+            current_line = int(line_token)
+            continue
+
+        if raw_line.startswith("+") and not raw_line.startswith("+++") and current_file:
+            yield current_file, raw_line[1:], current_line
+            current_line += 1
+
+
+def is_current_facing(path: str) -> bool:
+    if path in NON_CURRENT_FACING_NAMES:
+        return False
+    if any(path.startswith(prefix) for prefix in NON_CURRENT_FACING_PREFIXES):
+        return False
+    return any(path.startswith(prefix) for prefix in STRICT_CURRENT_FACING_PREFIXES)
+
+
+def should_check_rule(path: str, rule: DriftRule) -> bool:
+    if not is_current_facing(path):
+        return False
+    if rule.name == "docker-primary-pygpt":
+        return os.path.basename(path) == "Dockerfile"
+    if rule.name == "huey-core-label":
+        return path.endswith(".md")
+    if rule.name == "repo-py-gpt-path":
+        return True
+    if rule.name == "windows-hueybody-path":
+        return True
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", help="Git base ref/commit to diff against")
+    args = parser.parse_args()
+
+    rules = list(RULES)
+    if _is_pyhuey_canonical():
+        rules.append(
+            DriftRule(
+                name="integrations-pygpt-path",
+                pattern=re.compile(r"\bintegrations/pygpt\b"),
+                message="Use integrations/pyhuey as the canonical integration path.",
+            )
+        )
+
+    base_ref = resolve_base_ref(args.base)
+    strict_violations: list[str] = []
+    warnings: list[str] = []
+
+    for path, line, line_number in iter_added_lines(base_ref):
+        for rule in rules:
+            if not should_check_rule(path, rule):
+                continue
+            if rule.pattern.search(line):
+                entry = f"{path}:{line_number}: {rule.message}"
+                if rule.strict:
+                    strict_violations.append(entry)
+                else:
+                    warnings.append(entry)
+
+    if warnings:
+        print("Repo drift warnings:")
+        for warning in warnings:
+            print(f"- {warning}")
+
+    if strict_violations:
+        print("Repo drift check failed with strict current-facing violations:")
+        for violation in strict_violations:
+            print(f"- {violation}")
+        return 1
+
+    print("Repo drift check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Prevent accidental repo drift by catching stale path/branding strings introduced in current-facing files. 
- Ensure archive/provenance content is not unfairly flagged by focusing only on newly added lines in current-facing paths. 

### Description
- Add a diff-based low-noise checker at `scripts/check_repo_drift.py` that scans `base...HEAD` added lines for rules including `repo/py-gpt`, `platform/windows/hueybody`, `Huey Core` in docs, and `pygpt`/`pygpt-net` in Dockerfiles, and adds an `integrations/pygpt` rule only when `integrations/pyhuey` exists. 
- The checker prints actionable `file:line: message` warnings and returns nonzero only for strict current-facing violations. 
- Add `make check-drift` and wire the checker into `make lint` so it runs in local linting flows. 
- Add a CI lint-stage step to run `make check-drift` before the regular linters in `.github/workflows/ci.yml`.

### Testing
- Ran `python scripts/check_repo_drift.py` which printed `Repo drift check passed.` and exited 0. 
- Ran `make check-drift` after adjusting the Makefile; it invoked the script and returned success. 
- Ran existing stale-platform check `python scripts/check_stale_platform_strings.py`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a026722ded8832fafa852cc5e067ecd)