### PR TITLE
docs(deps): audit v101.1 dependency source of truth

### DIFF
--- a/docs/audits/v101.1-dependency-source-of-truth.md
+++ b/docs/audits/v101.1-dependency-source-of-truth.md
@@ -1,0 +1,109 @@
+# v101.1 Dependency Source-of-Truth Audit
+
+Date: 2026-05-12  
+Scope: `pyproject.toml`, `requirements.txt`, `constraints.txt`, CI workflows, Dockerfiles.
+
+## Goal
+Document current dependency authority boundaries to reduce truth drift and define one clear update rule for future changes.
+
+## Files inspected
+- `pyproject.toml`
+- `requirements.txt`
+- `constraints.txt`
+- `requirements-dev.txt` (not present)
+- `.github/workflows/ci.yml`
+- `.github/workflows/security-dependency-scan.yml`
+- `infra/docker/Dockerfile`
+- `infra/docker/pyhuey/Dockerfile`
+- `infra/docker/docker/Dockerfile`
+
+---
+
+## Current state (as of v101.1)
+
+### 1) Direct runtime dependencies (authoritative)
+**Authoritative file: `pyproject.toml`**
+
+Reason:
+- Runtime dependencies are explicitly declared in `[project].dependencies`.
+- Install surfaces used by CI and main Docker builds install from the package metadata (`pip install -e ".[dev]"` or `pip install .`/`pip install ".[extras]"), which resolves from `pyproject.toml`.
+
+### 2) Dev dependencies (authoritative)
+**Authoritative file: `pyproject.toml` (`[project.optional-dependencies].dev`)**
+
+Reason:
+- CI installs `-e ".[dev]"` in lint and test jobs.
+- No `requirements-dev.txt` exists in repository root.
+
+### 3) Full pinned freeze / reproducible baseline
+**Authoritative file: `requirements.txt`**
+
+Reason:
+- File comments identify it as the heavy, fully pinned baseline.
+- Security dependency audit currently runs `pip-audit -r requirements.txt`, making this file the current operational full lock baseline for scanning.
+
+### 4) Constraints / anchor pins
+**Authoritative file: `constraints.txt`**
+
+Reason:
+- File header declares it as global constraints/anchors.
+- `requirements.txt` consumes it via `-c constraints.txt`.
+- Makefile install targets use `-c constraints.txt` with editable installs.
+
+### 5) Docker install authority
+**Authoritative source: `pyproject.toml` for HueyOS runtime images; `pygpt-net` pin path for optional PyHuey cockpit image**
+
+Reason:
+- `infra/docker/Dockerfile` installs this repository package with optional extras (`pip install .` / `pip install ".[extras]"), so dependency source is `pyproject.toml`.
+- `infra/docker/docker/Dockerfile` also installs this repository with extras from package metadata.
+- `infra/docker/pyhuey/Dockerfile` intentionally installs `pygpt-net` directly for optional cockpit/provenance compatibility.
+
+### 6) CI install authority
+**Authoritative source: `pyproject.toml` for CI env creation; `requirements.txt` for security scan input**
+
+Reason:
+- `.github/workflows/ci.yml` uses `pip install -e ".[dev]"`.
+- `.github/workflows/security-dependency-scan.yml` runs `pip-audit -r requirements.txt`.
+
+---
+
+## Recommended v101.1 policy (single clear rule-set)
+
+1. **`pyproject.toml` is the authority for direct dependencies**
+   - Runtime direct deps: `[project].dependencies`
+   - Dev direct deps: `[project.optional-dependencies].dev`
+   - Feature groups (`ml`, `data`, `cloud`, `audio`) remain authoritative in `pyproject.toml`.
+
+2. **`requirements.txt` is the generated/maintained full pinned environment freeze**
+   - Treat it as the audited lock-style baseline used for reproducible installs and `pip-audit`.
+   - Do not hand-edit ad hoc unless emergency patching is required; prefer regeneration from authoritative dependency declarations and documented process.
+
+3. **`constraints.txt` is retained as shared anchor constraints**
+   - Keep it intentionally minimal and stable.
+   - Use for cross-surface alignment (`make install`, editable installs, and controlled install paths).
+
+4. **Install surface precedence**
+   - CI/dev/test env creation: package metadata from `pyproject.toml`.
+   - Security lock scanning: `requirements.txt`.
+   - Docker HueyOS runtime builds: package metadata from `pyproject.toml`.
+   - Docker optional PyHuey cockpit image: explicit `pygpt-net` install (separate intent).
+
+---
+
+## Follow-up TODOs
+
+- [ ] Add a small `docs/development/dependency-update-policy.md` runbook with exact commands for:
+  - updating direct deps in `pyproject.toml`,
+  - regenerating `requirements.txt`,
+  - validating with `pip check` and `pip-audit`.
+- [ ] Add a CI drift guard that fails when `pyproject.toml` direct dependency sets and top-level sections in `requirements.txt` diverge unexpectedly.
+- [ ] Decide whether to add an explicit generated marker/header in `requirements.txt` (e.g., “generated from pyproject + constraints process”) to prevent manual drift.
+- [ ] Evaluate whether `constraints.txt` should include only anchors not already strictly pinned via `pyproject.toml` to reduce duplication burden.
+- [ ] Optionally document why `security-dependency-scan.yml` targets `requirements.txt` while CI env provisioning targets `pyproject.toml` (intentional two-layer model).
+
+---
+
+## Non-goals / constraints for this task
+- No package versions were changed.
+- No dependency graph refactor was performed.
+- This is a documentation-only stabilization step for dependency truth boundaries.


### PR DESCRIPTION
### Motivation
- Reduce dependency truth-drift by auditing current dependency surfaces (`pyproject.toml`, `requirements.txt`, `constraints.txt`), CI install paths, and Docker build installs and produce one clear, small-scope policy for v101.1.

### Description
- Add `docs/audits/v101.1-dependency-source-of-truth.md` which records findings and declares `pyproject.toml` as the authority for direct runtime and dev deps, `requirements.txt` as the generated full pinned/freeze baseline, and `constraints.txt` as the shared anchor; it also maps CI and Docker install behavior and includes follow-up TODOs for a runbook and drift checks.

### Testing
- Ran repository inspections and smoke commands used by the audit (reading `pyproject.toml`, `requirements.txt`, `constraints.txt`, checking `.github` workflows and `infra/docker` Dockerfiles via `sed`/`rg`) and committed the new file; all inspection commands and `git commit` succeeded and no test suites were modified or run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a02785249b0832fa9b344257612709c)