### PR TITLE
chore(deps): add dependency sync guardrail script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PORT ?= 1995
 APP ?= huey.api:app
 PKG_COV ?= --cov=huey --cov=hueyos
 
-.PHONY: help setup install install-dev precommit-install format lint check-drift test coverage run run-reload health
+.PHONY: help setup install install-dev precommit-install format lint check-drift check-deps-sync test coverage run run-reload health
 
 help:
 	@echo "Common targets:"
@@ -22,6 +22,7 @@ help:
 	@echo "  make format           - run black + isort"
 	@echo "  make lint             - run drift checks + black/isort/ruff/flake8"
 	@echo "  make check-drift      - run repository drift checker"
+	@echo "  make check-deps-sync  - check pyproject/requirements/constraints sync"
 	@echo "  make test             - run pytest"
 	@echo "  make coverage         - run pytest with coverage for huey + hueyos"
 	@echo "  make run              - run FastAPI app via uvicorn"
@@ -54,6 +55,9 @@ lint:
 
 check-drift:
 	$(PYTHON) scripts/check_repo_drift.py
+
+check-deps-sync:
+	$(PYTHON) scripts/check_dependency_sync.py
 
 test:
 	$(PYTHON) -m pytest -q

--- a/scripts/check_dependency_sync.py
+++ b/scripts/check_dependency_sync.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Guardrail for obvious dependency drift across pyproject/requirements/constraints.
+
+Checks:
+- direct dependencies declared in pyproject.toml are present in requirements.txt
+- conflicting exact pins between pyproject and requirements.txt
+- conflicting exact pins between constraints.txt and requirements.txt
+
+This intentionally focuses on direct dependencies and exact-pin conflicts; it does not
+attempt to enforce equality for transitive dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from pathlib import Path
+from typing import Dict
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+
+
+def parse_requirement_line(line: str) -> Requirement | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    if stripped.startswith(("-r", "--requirement", "-c", "--constraint", "-e", "--editable")):
+        return None
+    try:
+        return Requirement(stripped)
+    except InvalidRequirement:
+        return None
+
+
+def collect_requirements(requirement_strings: list[str]) -> Dict[str, Requirement]:
+    result: Dict[str, Requirement] = {}
+    for req_text in requirement_strings:
+        req = parse_requirement_line(req_text)
+        if req is None:
+            continue
+        result[canonicalize_name(req.name)] = req
+    return result
+
+
+def read_requirements_file(path: Path) -> Dict[str, Requirement]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    return collect_requirements(lines)
+
+
+def load_pyproject_direct_requirements(path: Path) -> Dict[str, Requirement]:
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    project = data.get("project", {})
+    deps: list[str] = list(project.get("dependencies", []))
+    optional = project.get("optional-dependencies", {})
+    for extra_deps in optional.values():
+        deps.extend(extra_deps)
+    return collect_requirements(deps)
+
+
+def exact_pin(req: Requirement) -> str | None:
+    if len(req.specifier) != 1:
+        return None
+    spec = next(iter(req.specifier))
+    if spec.operator != "==":
+        return None
+    return spec.version
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pyproject", default="pyproject.toml")
+    parser.add_argument("--requirements", default="requirements.txt")
+    parser.add_argument("--constraints", default="constraints.txt")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return run_self_test()
+
+    pyproject_reqs = load_pyproject_direct_requirements(Path(args.pyproject))
+    requirements_reqs = read_requirements_file(Path(args.requirements))
+    constraints_reqs = read_requirements_file(Path(args.constraints))
+
+    missing_from_requirements: list[str] = []
+    pyproject_req_conflicts: list[str] = []
+    constraints_conflicts: list[str] = []
+
+    for name, py_req in sorted(pyproject_reqs.items()):
+        req_req = requirements_reqs.get(name)
+        if req_req is None:
+            missing_from_requirements.append(py_req.name)
+            continue
+        py_pin = exact_pin(py_req)
+        req_pin = exact_pin(req_req)
+        if py_pin and req_pin and py_pin != req_pin:
+            pyproject_req_conflicts.append(
+                f"{py_req.name}: pyproject={py_pin} requirements={req_pin}"
+            )
+
+    shared = sorted(set(constraints_reqs).intersection(requirements_reqs))
+    for name in shared:
+        con_pin = exact_pin(constraints_reqs[name])
+        req_pin = exact_pin(requirements_reqs[name])
+        if con_pin and req_pin and con_pin != req_pin:
+            constraints_conflicts.append(
+                f"{constraints_reqs[name].name}: constraints={con_pin} requirements={req_pin}"
+            )
+
+    had_issue = False
+    if missing_from_requirements:
+        had_issue = True
+        print("Direct dependencies missing from requirements.txt:")
+        for dep in missing_from_requirements:
+            print(f"  - {dep}")
+
+    if pyproject_req_conflicts:
+        had_issue = True
+        print("Conflicting exact pins between pyproject.toml and requirements.txt:")
+        for conflict in pyproject_req_conflicts:
+            print(f"  - {conflict}")
+
+    if constraints_conflicts:
+        had_issue = True
+        print("Conflicting exact pins between constraints.txt and requirements.txt:")
+        for conflict in constraints_conflicts:
+            print(f"  - {conflict}")
+
+    if had_issue:
+        return 1
+
+    print("Dependency sync check passed.")
+    return 0
+
+
+def run_self_test() -> int:
+    pyproject_req_map = collect_requirements(
+        ["corepkg==1.0.0", "sharedpkg==2.0.0", "optionalpkg==3.0.0"]
+    )
+    requirements_req_map = collect_requirements(
+        ["corepkg==1.0.0", "sharedpkg==2.1.0", "transitive-only==9.9.9"]
+    )
+    constraints_req_map = collect_requirements(["sharedpkg==2.2.0", "helper==0.1.0"])
+
+    missing = [n for n in pyproject_req_map if n not in requirements_req_map]
+    py_conflict = exact_pin(pyproject_req_map["sharedpkg"]) != exact_pin(
+        requirements_req_map["sharedpkg"]
+    )
+    con_conflict = exact_pin(constraints_req_map["sharedpkg"]) != exact_pin(
+        requirements_req_map["sharedpkg"]
+    )
+
+    assert "optionalpkg" in missing
+    assert py_conflict
+    assert con_conflict
+    print("Self-test passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Add a small guardrail to detect obvious drift between `pyproject.toml` and the pinned installer files so direct dependency contract drift is caught early. 
- The check focuses on direct dependencies and exact-pin conflicts and intentionally does not enforce equality for transitive packages.

### Description
- Add `scripts/check_dependency_sync.py` which parses `[project].dependencies` and `[project].optional-dependencies` from `pyproject.toml` and requirement lines from `requirements.txt` and `constraints.txt` using `tomllib` and `packaging` utilities. 
- The script reports three issues: direct dependencies missing from `requirements.txt`, conflicting exact pins between `pyproject.toml` and `requirements.txt`, and conflicting exact pins between `constraints.txt` and `requirements.txt`. 
- The script ignores `-r`, `-c`, and `-e` lines and non-parseable entries to reduce noise and includes a `--self-test` mode for a synthetic smoke validation. 
- Add `make check-deps-sync` target and `.PHONY`/help text so the guardrail can be run via `make`.

### Testing
- Ran `python scripts/check_dependency_sync.py --self-test` and it passed the built-in assertions. 
- Ran `python scripts/check_dependency_sync.py` against the repository files and the script executed correctly but reported a real pin mismatch (`types-PyYAML`), exiting non-zero. 
- Ran `make check-deps-sync` which propagated the non-zero exit (expected failure while the repository contains the detected drift).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0279108804832f818a17d0ee6989cc)