### PR TITLE
feat(runtime): add reusable V1 JSONL run-record writer

### DIFF
--- a/src/hueyos/runtime/logging.py
+++ b/src/hueyos/runtime/logging.py
@@ -1,0 +1,73 @@
+"""Structured JSONL logging helpers for HueyOS V1 run records."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+REQUIRED_V1_FIELDS = {
+    "run_id",
+    "timestamp_start",
+    "timestamp_end",
+    "source_file",
+    "transcript",
+    "response",
+    "transcription_engine",
+    "transcription_model",
+    "cognition_provider",
+    "cognition_model",
+    "runtime_seconds",
+    "exit_status",
+}
+
+
+def _normalize_json_value(value: Any) -> Any:
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise ValueError("record includes non-finite float value")
+        return value
+
+    if isinstance(value, Path):
+        return str(value)
+
+    if isinstance(value, dict):
+        normalized: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError("record contains non-string dictionary key")
+            normalized[key] = _normalize_json_value(item)
+        return normalized
+
+    if isinstance(value, (list, tuple)):
+        return [_normalize_json_value(item) for item in value]
+
+    raise TypeError(f"record contains non-JSON-safe value of type {type(value).__name__}")
+
+
+def validate_run_record(record: dict) -> dict:
+    """Validate and normalize a V1 run record for structured JSON output."""
+    if not isinstance(record, dict):
+        raise TypeError("record must be a dictionary")
+
+    missing = REQUIRED_V1_FIELDS - set(record.keys())
+    if missing:
+        missing_fields = ", ".join(sorted(missing))
+        raise ValueError(f"record missing required V1 field(s): {missing_fields}")
+
+    normalized = _normalize_json_value(record)
+    json.dumps(normalized, ensure_ascii=False, allow_nan=False)
+    return normalized
+
+
+def append_jsonl_record(path: str | Path, record: dict) -> None:
+    """Append one validated V1 run record to a JSONL file."""
+    normalized_record = validate_run_record(record)
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with output_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(normalized_record, ensure_ascii=False, allow_nan=False) + "\n")

--- a/tests/test_runtime_logging.py
+++ b/tests/test_runtime_logging.py
@@ -1,0 +1,51 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from hueyos.runtime.logging import append_jsonl_record, validate_run_record
+
+
+def _valid_record() -> dict:
+    return {
+        "run_id": "run-123",
+        "timestamp_start": "2026-05-12T00:00:00Z",
+        "timestamp_end": "2026-05-12T00:00:01Z",
+        "source_file": "fixture.mp3",
+        "transcript": "hello",
+        "response": {"text": "ack"},
+        "transcription_engine": "local",
+        "transcription_model": "whisper-small",
+        "cognition_provider": "mock-bridge",
+        "cognition_model": "mock-v1",
+        "runtime_seconds": 1.23,
+        "exit_status": "success",
+    }
+
+
+def test_append_jsonl_record_writes_valid_record(tmp_path: Path):
+    log_path = tmp_path / "logs" / "runs.jsonl"
+    record = _valid_record()
+
+    append_jsonl_record(log_path, record)
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    persisted = json.loads(lines[0])
+    assert persisted == record
+
+
+def test_validate_run_record_fails_when_required_field_missing():
+    record = _valid_record()
+    record.pop("response")
+
+    with pytest.raises(ValueError, match="response"):
+        validate_run_record(record)
+
+
+def test_validate_run_record_fails_for_non_json_safe_value():
+    record = _valid_record()
+    record["response"] = {"bad": {"nested-set"}}
+
+    with pytest.raises(TypeError, match="non-JSON-safe"):
+        validate_run_record(record)


### PR DESCRIPTION
### Motivation

- Provide a small, reusable JSONL writer for V1 run records so the V1 proof-loop can persist structured run information in a stable format.
- Ensure written records are strictly JSON-safe and validated without requiring any real model or network calls.

### Description

- Add `src/hueyos/runtime/logging.py` with `validate_run_record(record: dict) -> dict` and `append_jsonl_record(path, record) -> None` to validate, normalize, and persist V1 run records.
- Enforce required V1 fields (`run_id`, `timestamp_start`, `timestamp_end`, `source_file`, `transcript`, `response`, `transcription_engine`, `transcription_model`, `cognition_provider`, `cognition_model`, `runtime_seconds`, `exit_status`) and raise on missing fields.
- Normalize JSON-compatible values (convert `Path` to `str`, recursively normalize `dict`/`list`/`tuple`) and reject non-JSON-safe types and non-finite floats.
- Add `tests/test_runtime_logging.py` covering valid write, missing-field failure, and non-JSON-safe-value failure, and ensure `append_jsonl_record` creates parent directories when needed.

### Testing

- Ran `pytest -q tests/test_runtime_logging.py tests/test_v1_loop.py` and all targeted tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0279c0b438832f9f77ab4d3e27a3f2)