### PR TITLE
feat(runtime): add deterministic V1 fixture queue scaffolding

### DIFF
--- a/src/hueyos/runtime/queue.py
+++ b/src/hueyos/runtime/queue.py
@@ -1,0 +1,56 @@
+"""Deterministic fixture queue helpers for the V1 proof loop."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from shutil import move
+
+_IGNORED_SUFFIXES = {".partial", ".tmp"}
+
+
+def list_pending_fixtures(queue_dir: str | Path) -> list[Path]:
+    """Return pending fixture files in deterministic filename order."""
+    queue_path = Path(queue_dir)
+    if not queue_path.exists():
+        return []
+
+    pending = [
+        item
+        for item in queue_path.iterdir()
+        if item.is_file() and item.suffix not in _IGNORED_SUFFIXES
+    ]
+    return sorted(pending, key=lambda path: path.name)
+
+
+def claim_fixture(path: str | Path, runs_dir: str | Path) -> Path:
+    """Atomically claim a fixture by moving it into the active runs directory."""
+    source = Path(path)
+    destination_dir = Path(runs_dir)
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    destination = destination_dir / source.name
+    moved_to = move(str(source), str(destination))
+    return Path(moved_to)
+
+
+def mark_processed(path: str | Path, processed_dir: str | Path) -> Path:
+    """Move a processed fixture to the processed archive directory."""
+    source = Path(path)
+    destination_dir = Path(processed_dir)
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    destination = destination_dir / source.name
+    moved_to = move(str(source), str(destination))
+    return Path(moved_to)
+
+
+def mark_failed(path: str | Path, failed_dir: str | Path, reason: str) -> tuple[Path, Path]:
+    """Move a failed fixture to failed archive and write a sidecar reason file."""
+    source = Path(path)
+    destination_dir = Path(failed_dir)
+    destination_dir.mkdir(parents=True, exist_ok=True)
+
+    failed_fixture = destination_dir / source.name
+    moved_to = Path(move(str(source), str(failed_fixture)))
+
+    reason_path = destination_dir / f"{moved_to.name}.reason.txt"
+    reason_path.write_text(reason, encoding="utf-8")
+    return moved_to, reason_path

--- a/tests/test_runtime_queue.py
+++ b/tests/test_runtime_queue.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+from hueyos.runtime.queue import (
+    claim_fixture,
+    list_pending_fixtures,
+    mark_failed,
+    mark_processed,
+)
+
+
+def _write_file(path: Path, content: str = "fixture") -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def test_list_pending_fixtures_ignores_partial_and_tmp_and_sorts(tmp_path: Path) -> None:
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+
+    _write_file(queue_dir / "b_fixture.mp3")
+    _write_file(queue_dir / "a_fixture.mp3")
+    _write_file(queue_dir / "z_fixture.partial")
+    _write_file(queue_dir / "y_fixture.tmp")
+
+    pending = list_pending_fixtures(queue_dir)
+
+    assert [path.name for path in pending] == ["a_fixture.mp3", "b_fixture.mp3"]
+
+
+def test_claim_fixture_moves_file_to_runs_directory(tmp_path: Path) -> None:
+    queue_dir = tmp_path / "queue"
+    runs_dir = tmp_path / "runs"
+    queue_dir.mkdir()
+
+    source = queue_dir / "fixture.mp3"
+    _write_file(source, "audio")
+
+    claimed = claim_fixture(source, runs_dir)
+
+    assert claimed == runs_dir / "fixture.mp3"
+    assert not source.exists()
+    assert claimed.read_text(encoding="utf-8") == "audio"
+
+
+def test_mark_processed_moves_claimed_file(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    processed_dir = tmp_path / "processed"
+    runs_dir.mkdir()
+
+    fixture = runs_dir / "fixture.mp3"
+    _write_file(fixture, "done")
+
+    archived = mark_processed(fixture, processed_dir)
+
+    assert archived == processed_dir / "fixture.mp3"
+    assert not fixture.exists()
+    assert archived.read_text(encoding="utf-8") == "done"
+
+
+def test_mark_failed_preserves_file_and_writes_reason(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    failed_dir = tmp_path / "failed"
+    runs_dir.mkdir()
+
+    fixture = runs_dir / "fixture.mp3"
+    _write_file(fixture, "bad audio")
+
+    moved_fixture, reason_path = mark_failed(fixture, failed_dir, "transcription failed")
+
+    assert moved_fixture == failed_dir / "fixture.mp3"
+    assert not fixture.exists()
+    assert moved_fixture.read_text(encoding="utf-8") == "bad audio"
+    assert reason_path.read_text(encoding="utf-8") == "transcription failed"


### PR DESCRIPTION
### Motivation
- Provide a simple, deterministic file-based queue for the V1 proof loop without introducing live microphone or daemon assumptions.
- Avoid processing partially-copied fixtures by ignoring common temp suffixes during discovery.
- Preserve failed fixtures and record failure reasons for later inspection and recovery.

### Description
- Add `src/hueyos/runtime/queue.py` implementing `list_pending_fixtures`, `claim_fixture`, `mark_processed`, and `mark_failed` using `pathlib` and `shutil.move`.
- `list_pending_fixtures(queue_dir)` ignores files ending with `.partial` and `.tmp` and returns files sorted by filename for deterministic processing.
- `claim_fixture(path, runs_dir)` atomically moves a fixture into an active runs directory, `mark_processed(path, processed_dir)` archives processed fixtures, and `mark_failed(path, failed_dir, reason)` moves the fixture to a failed archive and writes a sidecar `*.reason.txt` file.
- Add `tests/test_runtime_queue.py` with focused unit tests for ordering/filtering, claiming, processed archival, and failed-file preservation.

### Testing
- Ran `pytest -q tests/test_runtime_queue.py` which executed the new tests and reported: `4 passed`.
- No external services, audio decoding, or live hardware were required by the tests; all checks are local and deterministic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a027a61a270832fa4bde909afdab33b)