### PR TITLE
feat(cli): add v1-run-queue mock queue processor

### DIFF
--- a/src/huey/memory/PY/cli.py
+++ b/src/huey/memory/PY/cli.py
@@ -368,6 +368,85 @@ def _cmd_v1_run(args: argparse.Namespace) -> int:
     return 0
 
 
+
+def _cmd_v1_run_queue(args: argparse.Namespace) -> int:
+    from hueyos.runtime.v1_loop import run_v1_loop
+
+    if not args.mock:
+        raise RuntimeError(
+            "Real transcription/cognition providers are disabled by default. "
+            "Use --mock or explicitly wire configured providers."
+        )
+
+    queue_dir = Path(args.queue_dir).expanduser().resolve()
+    if not queue_dir.exists() or not queue_dir.is_dir():
+        raise RuntimeError(f"Queue directory not found: {queue_dir}")
+
+    log_dir = Path(args.log_dir).expanduser().resolve()
+    log_dir.mkdir(parents=True, exist_ok=True)
+    processed_dir = queue_dir / "processed"
+    processed_dir.mkdir(parents=True, exist_ok=True)
+
+    fixtures = sorted(
+        [
+            path
+            for path in queue_dir.iterdir()
+            if path.is_file()
+            and path.suffix.lower() not in {".partial", ".tmp"}
+        ],
+        key=lambda path: path.name,
+    )
+
+    def _mock_transcribe(source_file: str) -> dict[str, str]:
+        if Path(source_file).stem.lower().startswith("fail"):
+            raise RuntimeError("mock fixture failure")
+        return {
+            "transcription_engine": "mock-transcriber",
+            "transcription_model": "mock-whisper-v1",
+            "transcript": f"mock transcript from {Path(source_file).name}",
+        }
+
+    def _mock_cognition(transcript: str) -> dict[str, Any]:
+        return {
+            "cognition_provider": "mock-cognition",
+            "cognition_model": "mock-cognition-v1",
+            "response": {
+                "status": "ok",
+                "summary": f"processed {len(transcript)} chars",
+            },
+        }
+
+    processed_count = 0
+    failed_count = 0
+    for fixture in fixtures:
+        log_path = log_dir / f"{fixture.name}.json"
+
+        def _write_json(record: dict[str, Any], target: Path = log_path) -> None:
+            with target.open("w", encoding="utf-8") as file_obj:
+                json.dump(record, file_obj, sort_keys=True)
+
+        record = run_v1_loop(fixture, _mock_transcribe, _mock_cognition, _write_json)
+        if record["exit_status"] == "success":
+            fixture.rename(processed_dir / fixture.name)
+            processed_count += 1
+        else:
+            failed_count += 1
+
+    print(
+        json.dumps(
+            {
+                "queue_dir": str(queue_dir),
+                "log_dir": str(log_dir),
+                "processed_dir": str(processed_dir),
+                "total": len(fixtures),
+                "processed": processed_count,
+                "failed": failed_count,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
 def main(argv: Iterable[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)

--- a/src/hueyos/cli/commands/runtime.py
+++ b/src/hueyos/cli/commands/runtime.py
@@ -78,3 +78,24 @@ def register_runtime_commands(subparsers: argparse._SubParsersAction[argparse.Ar
         help="Directory for run artifacts. Defaults to ./runs.",
     )
     v1_run_cmd.set_defaults(handler=_legacy_handler("_cmd_v1_run"))
+
+    v1_run_queue_cmd = subparsers.add_parser(
+        "v1-run-queue",
+        help="Run the CI-safe V1 proof loop across queued audio fixtures.",
+    )
+    v1_run_queue_cmd.add_argument(
+        "--mock",
+        action="store_true",
+        help="Use fake transcription/cognition providers (CI-safe default path).",
+    )
+    v1_run_queue_cmd.add_argument(
+        "--queue-dir",
+        required=True,
+        help="Directory containing queued fixtures.",
+    )
+    v1_run_queue_cmd.add_argument(
+        "--log-dir",
+        required=True,
+        help="Directory for per-fixture structured logs.",
+    )
+    v1_run_queue_cmd.set_defaults(handler=_legacy_handler("_cmd_v1_run_queue"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -211,3 +211,57 @@ def test_v1_run_mock_writes_structured_log(tmp_path: Path, capsys):
     assert required.issubset(record.keys())
     assert record["source_file"] == str(fixture.resolve())
     assert record["exit_status"] == "success"
+
+
+def test_v1_run_queue_mock_processes_sorted_and_handles_failures(tmp_path: Path, capsys):
+    queue_dir = tmp_path / "queue"
+    queue_dir.mkdir()
+    log_dir = tmp_path / "logs"
+
+    (queue_dir / "b-fixture.mp3").write_bytes(b"b")
+    (queue_dir / "a-fixture.mp3").write_bytes(b"a")
+    (queue_dir / "fail-fixture.mp3").write_bytes(b"f")
+    (queue_dir / "skip.partial").write_bytes(b"x")
+    (queue_dir / "skip.tmp").write_bytes(b"x")
+
+    exit_code = cli.main(
+        [
+            "v1-run-queue",
+            "--mock",
+            "--queue-dir",
+            str(queue_dir),
+            "--log-dir",
+            str(log_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["total"] == 3
+    assert output["processed"] == 2
+    assert output["failed"] == 1
+
+    processed_dir = queue_dir / "processed"
+    assert (processed_dir / "a-fixture.mp3").exists()
+    assert (processed_dir / "b-fixture.mp3").exists()
+    assert (queue_dir / "fail-fixture.mp3").exists()
+    assert (queue_dir / "skip.partial").exists()
+    assert (queue_dir / "skip.tmp").exists()
+
+    log_files = sorted(log_dir.glob("*.json"))
+    assert [path.name for path in log_files] == [
+        "a-fixture.mp3.json",
+        "b-fixture.mp3.json",
+        "fail-fixture.mp3.json",
+    ]
+
+    run_records = [json.loads(path.read_text(encoding="utf-8")) for path in log_files]
+    assert [Path(record["source_file"]).name for record in run_records] == [
+        "a-fixture.mp3",
+        "b-fixture.mp3",
+        "fail-fixture.mp3",
+    ]
+    assert run_records[0]["exit_status"] == "success"
+    assert run_records[1]["exit_status"] == "success"
+    assert run_records[2]["exit_status"] == "error"
+    assert run_records[2]["error_message_if_any"] == "mock fixture failure"


### PR DESCRIPTION
### Motivation
- Provide a CI-safe way to run the V1 proof loop across a directory of queued fixtures so batch runs can be tested without real audio or external APIs. 
- Ensure deterministic, sequential processing while skipping in-progress/temporary files and preserving failed fixtures for inspection.

### Description
- Register a new CLI subcommand `v1-run-queue` with flags `--mock`, `--queue-dir`, and `--log-dir` in `src/hueyos/cli/commands/runtime.py` and route to a legacy handler for compatibility. 
- Implement `_cmd_v1_run_queue` in `src/huey/memory/PY/cli.py` that scans `--queue-dir` in filename-sorted order, skips files with `.partial` and `.tmp` suffixes, and processes fixtures sequentially using the injected `run_v1_loop` flow. 
- For each fixture the command writes a single structured JSON log file into the provided `--log-dir`, moves successful fixtures into a `processed` subdirectory, and leaves failed fixtures in place while recording error details in their logs. 
- Add a deterministic integration-style unit test `test_v1_run_queue_mock_processes_sorted_and_handles_failures` to `tests/test_cli.py` that uses temporary directories and fake fixtures to verify ordering, skip behavior, successful moves, and preserved failures without external dependencies.

### Testing
- Ran `pytest -q tests/test_cli.py -k 'v1_run'`, which executed the V1-related tests and completed successfully with the new queue test included (result: `2 passed, 6 deselected`).
- The added test exercises the queue scanning, log creation, success move, and failure preservation paths using only in-repo mocks and temp directories.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a027b430530832fa07f0122f80ca61c)