### PR TITLE
docs(runbook): add Huey Brain V1 Legion Go setup runbook

### DIFF
--- a/docs/runbooks/huey-brain-v1-legion-go.md
+++ b/docs/runbooks/huey-brain-v1-legion-go.md
@@ -1,0 +1,145 @@
+# Huey Brain V1 Setup Runbook (Legion Go Boundary)
+
+## Scope and boundary
+
+- This runbook is for **Huey Brain V1** on the **Lenovo Legion Go** boundary only.
+- V1 proof loop target in this repository is:
+  **controlled MP3 fixture → local transcription stub/mock path → cognition bridge stub/mock path → structured log**.
+- This runbook does **not** enable or claim live microphone ingestion, wake-word, or Huey Body integration.
+
+## Target OS note (Debian / Forky)
+
+- Use a Debian-family Linux target appropriate for the current HueyOS stabilization direction.
+- If your Legion Go host is on a Debian "Forky" path, keep this runbook as a conservative baseline and pin package decisions per your host policy.
+- All commands below assume a Debian-family package manager (`apt`).
+
+## 1) Python 3.13 setup
+
+```bash
+python3.13 --version
+```
+
+If missing:
+
+```bash
+sudo apt update
+sudo apt install -y python3.13 python3.13-venv python3.13-dev
+```
+
+Re-check:
+
+```bash
+python3.13 --version
+```
+
+## 2) Create and activate virtualenv
+
+From repository root:
+
+```bash
+cd /path/to/Monkey-Head-Project
+python3.13 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+```
+
+## 3) Install ffmpeg
+
+```bash
+sudo apt install -y ffmpeg
+ffmpeg -version
+```
+
+> Note: the mock V1 path below does not decode real audio, but `ffmpeg` is included because it is part of expected audio tooling for future real transcription wiring.
+
+## 4) Install project
+
+Editable install from repo root:
+
+```bash
+python -m pip install -e .
+```
+
+Optional dependency sanity check:
+
+```bash
+pip check
+```
+
+## 5) Fixture directory layout (controlled inputs)
+
+Create a deterministic local fixture layout:
+
+```bash
+mkdir -p fixtures/v1/incoming fixtures/v1/processed fixtures/v1/failed runs
+```
+
+Recommended conventions:
+
+- `fixtures/v1/incoming/` → queued controlled fixture files
+- `fixtures/v1/processed/` → archived after successful queue runs
+- `fixtures/v1/failed/` → failed fixtures and sidecar reason files
+- `runs/` → structured output logs
+
+For single-run mock smoke tests, create a placeholder MP3 fixture path:
+
+```bash
+touch fixtures/v1/incoming/mock_fixture.mp3
+```
+
+## 6) Mock V1 run command (implemented path)
+
+This is the executable CI-safe path currently available:
+
+```bash
+huey v1-run fixtures/v1/incoming/mock_fixture.mp3 --mock --log-dir runs
+```
+
+Expected behavior:
+
+- command exits successfully
+- prints JSON containing `log_file` and `run_id`
+- appends one JSON line record to `runs/v1-run.jsonl`
+
+Quick verification:
+
+```bash
+tail -n 1 runs/v1-run.jsonl
+```
+
+## 7) Structured log location
+
+Primary log artifact for `v1-run`:
+
+- `runs/v1-run.jsonl`
+
+Queue mode (`v1-run-queue`) writes per-fixture JSON logs to the directory supplied via `--log-dir`.
+
+## 8) Real transcription path (placeholder, not implemented here)
+
+> **Status: NOT IMPLEMENTED IN THIS RUNBOOK**
+
+Current CLI behavior requires `--mock` by default and explicitly blocks real provider flow unless custom provider wiring is added in code/runtime configuration.
+
+Future work item (not part of this runbook):
+
+- wire a real local transcription function and real cognition bridge provider
+- preserve the same V1 structured log contract
+- keep fixture-first deterministic input semantics for proofability
+
+## 9) SSH ingress note (operator access)
+
+SSH is an ingress/operations mechanism only; it does not change V1 boundaries.
+
+Typical ingress pattern:
+
+```bash
+ssh <user>@<legion-go-host>
+```
+
+Recommended operational posture:
+
+- use key-based auth
+- restrict users/groups
+- keep run artifacts under controlled directories (`fixtures/`, `runs/`)
+- perform V1 commands directly on the Legion Go host to preserve locality


### PR DESCRIPTION
### Motivation

- Provide an operator-facing, executable runbook that documents the V1 proof-loop boundary for Huey Brain (Legion Go) without overclaiming live mic, Huey Body, or HIMS integration.
- Align documentation with the existing CI-safe mock path in the codebase so operators can run a deterministic fixture-first smoke test and produce structured V1 logs.

### Description

- Add a new runbook `docs/runbooks/huey-brain-v1-legion-go.md` that covers Debian/Forky notes, Python 3.13 setup, `virtualenv` creation, `ffmpeg` install rationale, and project editable install steps.
- Document a deterministic fixture directory layout and provide a concrete mock command to run the implemented CI-safe path: `huey v1-run fixtures/v1/incoming/mock_fixture.mp3 --mock --log-dir runs`.
- Clearly mark real transcription/cognition wiring as a future work item and preserve the V1 boundary as the Legion Go proof loop with structured JSONL logging (`runs/v1-run.jsonl`).
- Add an SSH ingress guidance section that explains operational posture while keeping run artifacts and fixture semantics local and controlled.

### Testing

- Performed repository inspections and searches (`rg`/`sed`) to verify CLI and runtime implementations and confirm the documented `v1-run` mock path, and all inspection commands succeeded. 
- Created and committed the new file and verified the commit succeeded (`git add` / `git commit`).
- No new unit tests were added or executed for runtime behaviour in this change, and the runbook documents the mock execution command for operator verification rather than executing it in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a027cde8878832f9fd61cd03a36e40f)