### PR TITLE
chore(github): add issue templates for bug, feature, and docs with SECURITY.md guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Report a reproducible problem in Monkey-Head-Project, HueyOS, or PyHuey.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking time to report this issue.
+
+        **Security note:** If you are reporting a security vulnerability, do not open a public issue. Please report it privately following [SECURITY.md](../../SECURITY.md).
+  - type: dropdown
+    id: operating_system
+    attributes:
+      label: Operating system
+      description: What OS are you using?
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: python_version
+    attributes:
+      label: Python version
+      description: Output of `python --version`.
+      placeholder: "Python 3.11.9"
+    validations:
+      required: true
+  - type: dropdown
+    id: install_method
+    attributes:
+      label: Install method
+      description: How did you install the project?
+      options:
+        - pip install from PyPI
+        - pip install from source (local clone)
+        - Docker
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: command_run
+    attributes:
+      label: Command run
+      description: Exact command that triggered the problem.
+      placeholder: "python -m huey --help"
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual behavior
+      description: What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and traceback
+      description: |
+        Paste relevant logs/traceback. **Redact secrets** (API keys, tokens, passwords, private URLs, etc.) before posting.
+      render: shell
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability report
+    url: https://github.com/DylanLRPollock/Monkey-Head-Project/blob/main/SECURITY.md
+    about: Report security vulnerabilities privately via the process described in SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs_issue.yml
@@ -1,0 +1,34 @@
+name: Documentation issue
+description: Report missing, unclear, or incorrect documentation.
+title: "[Docs]: "
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve documentation.
+
+        **Security note:** Security vulnerabilities must be reported privately, not as public issues. See [SECURITY.md](../../SECURITY.md).
+  - type: input
+    id: docs_location
+    attributes:
+      label: Documentation location
+      description: Which file/page/section is affected?
+      placeholder: "README.md section 'Installation'"
+    validations:
+      required: true
+  - type: textarea
+    id: issue
+    attributes:
+      label: What is wrong or missing?
+      description: Describe the docs issue clearly.
+    validations:
+      required: true
+  - type: textarea
+    id: suggested_fix
+    attributes:
+      label: Suggested fix
+      description: What should the docs say instead?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Suggest an improvement for Monkey-Head-Project, HueyOS, or PyHuey.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion.
+
+        **Security note:** Do not report security vulnerabilities in public issues. Please use [SECURITY.md](../../SECURITY.md) for private reporting.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem are you trying to solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the change you want to see.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative approaches you've considered.
+    validations:
+      required: false


### PR DESCRIPTION
### Motivation
- Improve the quality of incoming bug/feature/docs reports by collecting targeted diagnostic information and reducing back-and-forth triage.
- Ensure security vulnerabilities are not disclosed in public issues by directing reporters to the repository `SECURITY.md` private disclosure process.

### Description
- Add GitHub issue form files: `.github/ISSUE_TEMPLATE/bug_report.yml`, `.github/ISSUE_TEMPLATE/feature_request.yml`, and `.github/ISSUE_TEMPLATE/docs_issue.yml` with user-friendly prompts and labels.
- Implement a `bug_report` form that requires `Operating system`, `Python version`, `Install method`, `Command run`, `Expected behavior`, `Actual behavior`, and `Logs` with an explicit instruction to redact secrets.
- Add `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues and provide a `Security vulnerability report` contact link that points to `SECURITY.md`.
- Include an explicit security note in all templates advising reporters to follow the private reporting flow in `SECURITY.md` rather than opening public issues.

### Testing
- Created files inspected via `nl -ba .github/ISSUE_TEMPLATE/*.yml` to verify content and structure, and the commands completed successfully.
- Ran `git add` and `git commit` to ensure the new templates were staged and committed, and the commit succeeded.
- No runtime code changed so no unit tests were required; all automated commands used for verification succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a027defbd18832f9abd064e75c6caab)