### PR TITLE
chore(repo): add v101.1 PR template with boundary checks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Summary
+- 
+
+## Why
+- 
+
+## Scope
+- In scope:
+  - 
+- Out of scope:
+  - 
+
+## Tests run
+- [ ] `...`
+- [ ] `...`
+
+## Screenshots/logs if UI
+- N/A or attach screenshots/log snippets.
+
+## Security considerations
+- Any security impact, sensitive surfaces touched, or risk mitigations.
+
+## Docs updated
+- [ ] Yes
+- [ ] No (explain why)
+
+## Dependency changes
+- [ ] None
+- [ ] Yes (list package, version change, and reason)
+
+## Boundary check
+- [ ] Does this keep PyHuey as cockpit/tooling?
+- [ ] Does this keep Huey Brain V1 on Legion Go?
+- [ ] Does this avoid implying Huey Body/HIMS/live mic are active?


### PR DESCRIPTION
### Motivation
- Add a standardized PR template aligned with v101.1 to ensure contributors include required context and to reinforce project boundaries (PyHuey as cockpit/tooling, Huey Brain V1 on Legion Go, and avoid suggesting Huey Body/HIMS/live mic are active).

### Description
- Create `.github/pull_request_template.md` containing sections Summary, Why, Scope, Tests run, Screenshots/logs if UI, Security considerations, Docs updated, Dependency changes, and a Boundary check checklist that explicitly asks: keep PyHuey as cockpit/tooling; keep Huey Brain V1 on Legion Go; and avoid implying Huey Body/HIMS/live mic are active.

### Testing
- No runtime tests required for a template-only change; validated the file exists and its contents with `nl -ba .github/pull_request_template.md` as a workspace smoke-check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a027ec1db4c832f882242c5d31e0921)