### PR TITLE
docs(changelog): add v101.1 stabilization changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+- Documentation and audit tracking continue for v101.1 stabilization work; no additional completed items are recorded here yet.
+
+## [101.1] - 2026-05-12
+
+### Added
+- Package build/install smoke workflow for wheel/sdist build, fresh-environment install, import checks (`huey`, `hueyos`, `huey.api`), and CLI checks (`huey --help`, `huey-api --help`).
+- Security policy document for Bandit baseline usage and CI enforcement of new medium/high findings.
+
+### Changed
+- PyHuey cockpit alignment phase 1: added `pyhuey` console-script alias while retaining `pygpt`, updated package description/URLs for PyHuey cockpit identity, and preserved upstream PyGPT compatibility/provenance.
+- Namespace migration kickoff documented with canonical `hueyos` direction and `huey` compatibility path preserved during transition.
+- Docker alignment documented for v101.1 with HueyOS runtime expectations (`huey-api`, non-root `hueyos`, repository package install) instead of PyGPT as primary runtime.


### PR DESCRIPTION
### Motivation
- Capture v101.1 stabilization work in a single authoritative changelog while avoiding claims about unfinished or unverified work.
- Record only items that are already documented in the repository (PyHuey identity/branding audit, namespace migration notes, packaging smoke workflow, Docker alignment audit, and Bandit baseline policy).

### Description
- Add `CHANGELOG.md` in Keep a Changelog format with an `Unreleased` section and a `[101.1] - 2026-05-12` entry that lists only completed, documented items.
- The `101.1` entry records: package build/install smoke workflow, Bandit baseline policy, PyHuey cockpit alignment phase 1, namespace migration kickoff direction, and Docker alignment outcome.
- No runtime or source-code behavior was modified; this is a documentation-only change that references existing audit and workflow files under `docs/` and `.github/workflows/`.

### Testing
- Executed repository inspection and validation commands to ground changelog entries, including `rg` searches for relevant docs, viewing audit files with `sed -n`, and printing the new `CHANGELOG.md` with `nl -ba`; all commands completed successfully.
- Did not modify or run unit test suites; no automated unit tests were added or changed in this PR.
- CI smoke and security checks described in the changelog (package smoke workflow and Bandit baseline) remain available to run in CI as documented.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0280989f5c832fad98eb57205a185f)