### PR TITLE
Reject published example API token in non-development environments

### DIFF
--- a/src/huey/memory/PY/api.py
+++ b/src/huey/memory/PY/api.py
@@ -249,6 +249,7 @@ _TOKEN_PLACEHOLDER_VALUES = {
     "changeme",
     "change-me",
     "replace-me",
+    "replace-with-a-strong-secret-token",
     "replace_this",
     "replace-this",
     "placeholder",

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -120,6 +120,14 @@ def test_api_startup_fails_with_placeholder_token_in_non_development_env(monkeyp
         importlib.reload(api_module)
 
 
+def test_api_startup_fails_with_example_token_in_non_development_env(monkeypatch):
+    monkeypatch.setenv("HUEY_ENV", "production")
+    monkeypatch.setenv("HUEY_API_TOKEN", "replace-with-a-strong-secret-token")
+
+    with pytest.raises(RuntimeError, match="HUEY_API_TOKEN must be set"):
+        importlib.reload(api_module)
+
+
 def test_api_startup_allows_missing_token_in_development_env(monkeypatch):
     monkeypatch.setenv("HUEY_ENV", "development")
     monkeypatch.delenv("HUEY_API_TOKEN", raising=False)


### PR DESCRIPTION
### Motivation
- The repository’s example env file ships a concrete bearer token (`replace-with-a-strong-secret-token`) which the startup placeholder detector did not recognize, allowing an operator to expose the API with a known token.
- The change ensures non-development deployments fail fast when the example placeholder token is used so the control API is not accidentally exposed.

### Description
- Add the published example token `replace-with-a-strong-secret-token` to the `_TOKEN_PLACEHOLDER_VALUES` denylist used by `_looks_like_placeholder_token` in `src/huey/memory/PY/api.py` so it is treated as a placeholder. 
- Add a regression test `test_api_startup_fails_with_example_token_in_non_development_env` in `tests/test_api_routes.py` asserting import-time startup validation raises `RuntimeError` when `HUEY_ENV=production` and `HUEY_API_TOKEN` is the published example token.

### Testing
- Ran `python -m compileall src/huey/memory/PY/api.py tests/test_api_routes.py` which succeeded. 
- Attempted `pytest -q tests/test_api_routes.py -k 'startup_fails_with_placeholder_token_in_non_development_env or startup_fails_with_example_token_in_non_development_env'` but collection failed in this environment with `ImportError: cannot import name 'api' from 'huey.memory.PY'`, which prevented running the test cases here. 
- The change is intentionally minimal and targets a known placeholder string to avoid altering runtime authentication semantics for real secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7096b3b04832f803f5a29360742fd)