### PR TITLE
docs(audit): add v101.1 stabilization final report

### DIFF
--- a/docs/audits/v101.1-stabilization-final.md
+++ b/docs/audits/v101.1-stabilization-final.md
@@ -1,0 +1,80 @@
+# v101.1 Stabilization Final Audit
+
+Date: 2026-05-12 (UTC)
+Repository: Monkey-Head-Project
+Audit scope: final stabilization verification for v101.1 direction and baseline command health.
+
+## Completed tasks
+
+- Collected repository working tree state.
+- Collected Python runtime version.
+- Ran dependency integrity check (`pip check`).
+- Ran full pytest collection/execution attempt (`pytest -q`).
+- Ran lint target (`make lint`) and captured failures.
+- Ran drift/canon verification targets:
+  - `make check-drift`
+  - `make check-canon`
+- Attempted package build (`python -m build`) because `pyproject.toml` exists.
+- Evaluated Docker/Compose and PyHuey smoke-test requirement gates.
+
+## Commands run
+
+```bash
+git status --short
+python --version
+pip check
+pytest -q
+make lint
+make -qp | rg '^check-drift:|^check-canon:|^lint:'
+make check-drift
+make check-canon
+test -f pyproject.toml && echo yes || echo no
+python -m build
+```
+
+## Results (pass/fail)
+
+- PASS: `git status --short` (clean output before this audit document was created).
+- PASS: `python --version` → Python 3.13.13.
+- PASS: `pip check` → "No broken requirements found."
+- FAIL: `pytest -q` → interrupted with 12 import/collection errors and 14 skips.
+  - Observed failure classes include:
+    - `ModuleNotFoundError` for `hueyos.core.system_checks`.
+    - FastAPI import error (`JSONResponse` from vendored `fastapi.responses`).
+    - Circular import in honeycomb backup compatibility layer.
+    - File-not-found path expectation for `huey/memory/PY/error_handler.py` at repo root path.
+- FAIL: `make lint` → fails at `black --check` (77 files would be reformatted).
+- PASS: `make check-drift`.
+- PASS: `make check-canon`.
+- FAIL: `python -m build` → `No module named build` in current environment.
+
+## Docker/Compose validation status
+
+- Not run in this audit pass.
+- Reason: this task did not modify Docker/Compose files, and there was no explicit Docker-change delta in this run to validate.
+
+## PyHuey launch smoke test status
+
+- Not run in this audit pass.
+- Reason: this task did not modify PyHuey runtime/launch surfaces and focused on stabilization audit checks requested above.
+
+## Known remaining issues
+
+1. Test collection/import stability is currently broken across compatibility and namespace migration boundaries.
+2. Code formatting baseline is not clean under `black --check`.
+3. Packaging build prerequisite (`build` module) is missing from active environment.
+4. Optional dependency coverage causes multiple test skips (expected in lean environment), but hard import errors currently block meaningful full-suite pass/fail confidence.
+
+## No false completion statement
+
+This audit does **not** claim v101.1 technical completion. It records current command outcomes exactly as observed, including failures and skipped validation gates.
+
+## Next recommended task
+
+Prioritize a focused compatibility repair pass for import/runtime boundaries (especially `hueyos.core.system_checks`, vendored FastAPI response imports, and honeycomb circular imports), then re-run:
+
+1. `pytest -q`
+2. `make lint`
+3. `python -m build` (after installing `build` in the test environment)
+
+Only after those pass should Docker/Compose and PyHuey smoke gates be re-evaluated as release blockers for final stabilization sign-off.


### PR DESCRIPTION
### Motivation
- Produce a final, honest v101.1 stabilization audit artifact that records exact commands run, pass/fail outcomes, known remaining issues, and a clear next recommended task for follow-up.

### Description
- Add `docs/audits/v101.1-stabilization-final.md`, a committed audit document that captures completed tasks, the exact commands executed, pass/fail results, known remaining issues, a no-false-completion statement, and the next recommended stabilization steps (commit message: `docs(audit): add v101.1 stabilization final report`).

### Testing
- Executed repository health and CI-facing checks: `git status --short` (clean), `python --version` (3.13.13), `pip check` (no broken requirements), `pytest -q` (failed during collection with 12 import/collection errors and 14 skipped tests), `make lint` (failed: `black --check` indicates 77 files would be reformatted), `make check-drift` (passed), `make check-canon` (passed), and `python -m build` (failed: `No module named build`); Docker/Compose and PyHuey smoke tests were not run in this pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0287f97d98832f8f8bc0d4bbc2103a)