### PR TITLE
docs(api): add v101.1 FastAPI auth reality audit

### DIFF
--- a/docs/audits/v101.1-api-auth-reality.md
+++ b/docs/audits/v101.1-api-auth-reality.md
@@ -1,0 +1,138 @@
+# v101.1 API Auth Reality Audit
+
+Date: 2026-05-12  
+Scope: FastAPI runtime behavior and tests in current repository state.
+
+## Commands run
+
+- `sed -n '1,260p' src/hueyos/api/app.py`
+- `sed -n '1,260p' src/hueyos/api/auth.py`
+- `sed -n '1,260p' src/hueyos/api/routers/tasks.py`
+- `sed -n '1,260p' src/hueyos/api/routers/system.py`
+- `sed -n '1,260p' src/hueyos/api/routers/power.py`
+- `sed -n '1,260p' src/hueyos/api/routers/network.py`
+- `sed -n '1,320p' src/huey/memory/PY/api.py`
+- `sed -n '320,370p' src/huey/memory/PY/api.py`
+- `sed -n '1240,1375p' src/huey/memory/PY/api.py`
+- `sed -n '1350,1425p' src/huey/memory/PY/api.py`
+- `rg -n "@app\\.(get|post)\\(\\\"/(power|network|telemetry|tasks|healthz|dashboard)|def (battery_status|power_should_shutdown|trigger_shutdown|network_status|ensure_network_connectivity|list_recent_sensor_telemetry|list_recent_ai_interactions|submit_task)" src/huey/memory/PY/api.py`
+- `rg -n "include_router|middleware|Authorization|Bearer|_PUBLIC_PATHS|_require_privileged_surface_access|_require_unsafe_task_submission_access" src/huey/memory/PY/api.py`
+- `sed -n '1,280p' docs/security/threat-model-v101.1.md`
+- `sed -n '1,260p' tests/test_api_routes.py`
+
+## Reality summary
+
+The current API has **partial, environment-driven bearer-token authentication**:
+
+- A global middleware enforces `Authorization: Bearer <token>` on all routes **only when** `HUEY_API_TOKEN` is set.
+- `/healthz` is explicitly exempt from token enforcement.
+- When `HUEY_API_TOKEN` is **unset**, most endpoints are accessible without bearer auth unless additional per-endpoint gating is implemented.
+
+This means authn is **not universally required by code**; it is conditional on secure deployment configuration.
+
+---
+
+## Findings by requested category
+
+### 1) Authentication (authn)
+
+**Current state:** Conditional bearer-token auth via middleware.
+
+- `require_api_token` checks `HUEY_API_TOKEN` and validates bearer token using constant-time compare.
+- If token is unset, middleware bypasses auth checks.
+
+**Practical effect:**
+
+- Token configured => non-public endpoints require bearer token.
+- Token unset => endpoints rely on per-endpoint logic (if any), otherwise open.
+
+### 2) Authorization (authz)
+
+**Current state:** Coarse-grained and limited.
+
+- No role/permission model (admin/operator/read-only distinctions absent).
+- Extra authz-like gate exists for “privileged surfaces” when token is unset (`_require_privileged_surface_access`) and is used only on specific paths (e.g., dashboard and unsafe task submission path).
+
+**Practical effect:**
+
+- With token configured, any holder of that token gets broad API access.
+- With token unset, only selected endpoints enforce local-only restrictions.
+
+### 3) Bearer token enforcement
+
+**Current state:** Implemented globally but optional by configuration.
+
+- Middleware protects all routes except `_PUBLIC_PATHS`.
+- `_PUBLIC_PATHS` currently contains only `/healthz`.
+
+### 4) Health endpoint exemptions
+
+**Current state:** Explicitly exempt and unauthenticated.
+
+- `/healthz` bypasses bearer token checks even when token is configured.
+
+### 5) Unsafe task gating
+
+**Current state:** Explicit and stricter than base auth.
+
+- `POST /tasks` calls `_require_unsafe_task_submission_access`.
+- Gate requires:
+  - privileged surface access check (local-only fallback when token unset), and
+  - `HUEY_ENABLE_UNSAFE_TASKS=true`, except development-only authenticated fallback.
+
+**Practical effect:**
+
+- Unsafe submission is denied by default unless explicitly enabled (or allowed in a narrow dev+token case).
+
+### 6) Telemetry endpoint protection
+
+**Current state:** Protected only by global bearer middleware when token is set.
+
+- `/telemetry/sensors/recent` and `/telemetry/ai/recent` have no extra local-only or role gate.
+- If token unset, these endpoints are readable without auth.
+
+### 7) Power/network endpoint protection
+
+**Current state:** Protected only by global bearer middleware when token is set.
+
+- `/network/status`, `/network/ensure`, `/power/battery`, `/power/should-shutdown`, `/power/shutdown` are routed through split routers but do not add explicit per-endpoint access checks.
+- If token unset, they are callable without auth.
+
+---
+
+## Test evidence snapshot
+
+`tests/test_api_routes.py` confirms:
+
+- `/healthz` remains accessible while `/tasks` is blocked without bearer token when token configured.
+- task submission default-denied when unsafe flag is off.
+- remote access to task/dashboard is blocked when token is unset.
+
+No equivalent tests currently assert local-only or explicit authz for telemetry/power/network when token is unset.
+
+---
+
+## Threat-model mismatch check
+
+- Current `docs/security/threat-model-v101.1.md` already describes an **optional bearer-token gate** and a coarse control posture.
+- It does **not** claim universal mandatory authn for all endpoints regardless of configuration.
+
+Conclusion: there is **no direct “threat model says no auth” mismatch** requiring immediate threat-model correction. The model is directionally aligned with code reality, but this audit adds endpoint-level precision.
+
+---
+
+## Obvious exposure assessment (for this task)
+
+Potentially sensitive operational endpoints (telemetry, power, network) are open when `HUEY_API_TOKEN` is unset. This appears to be a **known current posture** (configuration-dependent security), not an accidental one-line regression in this diff.
+
+Per instruction, behavior is not changed in this task.
+
+---
+
+## Recommended next small steps (no behavior change in this patch)
+
+1. Add explicit tests documenting current token-unset behavior for telemetry/power/network.
+2. Decide policy for token-unset mode:
+   - either enforce local-only access on telemetry/power/network, or
+   - document these as intentionally open in dev-only profiles and block production startup if unset.
+3. Introduce minimal authz tiers (read vs control) after policy decision.


### PR DESCRIPTION
### Motivation

- Record the actual runtime authn/authz posture of the FastAPI control surface to support careful, incremental hardening decisions. 
- Preserve a test- and code-backed audit that checks the repository threat-model assumptions against reality without changing runtime behavior.

### Description

- Add `docs/audits/v101.1-api-auth-reality.md` containing commands run, evidence, endpoint-by-endpoint findings (authentication, authorization, bearer-token enforcement, health exemption, unsafe task gating, telemetry, and power/network protections), and recommended next steps. 
- The audit documents that bearer-token middleware is effective only when `HUEY_API_TOKEN` is set, `/healthz` is exempt, unsafe task submission uses a stricter per-endpoint gate, and telemetry/power/network endpoints rely on the global token middleware (therefore open when the token is unset). 
- No runtime behavior or code paths were modified in this change; this is documentation-only to capture current reality and support follow-up patches.

### Testing

- Ran the API route test module: `pytest -q tests/test_api_routes.py`; collection failed during import because the vendored FastAPI stub in this environment does not export `JSONResponse`, producing an `ImportError` (test run did not reach route assertions). 
- Audit generation involved inspecting the key files listed inside the document (for example `src/huey/memory/PY/api.py`, `src/hueyos/api/auth.py`, router modules, and `docs/security/threat-model-v101.1.md`) and enumerating the observed behaviors noted in the report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0289a6dd40832f8ea17555d0fc1b25)