### PR TITLE
security(api): require strong auth on dangerous endpoints

### DIFF
--- a/src/huey/memory/PY/api.py
+++ b/src/huey/memory/PY/api.py
@@ -294,6 +294,29 @@ def _require_privileged_surface_access(request: Request) -> None:
     )
 
 
+def require_strong_api_auth(request: Request) -> None:
+    """Require explicit bearer-token authentication for dangerous endpoints."""
+
+    expected_token = _configured_api_token()
+    if not expected_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="API token authentication is required for this endpoint",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    scheme, _, supplied_token = request.headers.get("authorization", "").partition(" ")
+    if scheme.lower() != "bearer" or not hmac.compare_digest(
+        supplied_token,
+        expected_token,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing or invalid API token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
 def _require_unsafe_task_submission_access(request: Request) -> None:
     """Enforce defensive gating for free-form task submission surfaces.
 
@@ -1523,9 +1546,10 @@ def locate_pdf(
     status_code=status.HTTP_202_ACCEPTED,
     tags=["Memory"],
 )
-def auto_sort(request: AutoSortRequest) -> AutoSortResponse:
+def auto_sort(request: AutoSortRequest, http_request: Request) -> AutoSortResponse:
     """Trigger automated organisation of files in the HueyOS memory directory."""
 
+    require_strong_api_auth(http_request)
     try:
         summary = auto_sort_memory(
             source_dir=request.source_dir,
@@ -1662,9 +1686,12 @@ def emergency_status() -> EmergencyStatusResponse:
     response_model=EmergencyStatusResponse,
     tags=["Governance"],
 )
-def enter_emergency_mode(request: EmergencyModeRequest) -> EmergencyStatusResponse:
+def enter_emergency_mode(
+    request: EmergencyModeRequest, http_request: Request
+) -> EmergencyStatusResponse:
     """Enter emergency mode after validating approvals."""
 
+    require_strong_api_auth(http_request)
     try:
         EMERGENCY_CONTROLLER.enter_emergency_mode(
             triggered_by=request.triggered_by,
@@ -1687,9 +1714,12 @@ def enter_emergency_mode(request: EmergencyModeRequest) -> EmergencyStatusRespon
     response_model=EmergencyStatusResponse,
     tags=["Governance"],
 )
-def exit_emergency_mode(request: EmergencyExitRequest) -> EmergencyStatusResponse:
+def exit_emergency_mode(
+    request: EmergencyExitRequest, http_request: Request
+) -> EmergencyStatusResponse:
     """Exit emergency mode when sufficient approvals are provided."""
 
+    require_strong_api_auth(http_request)
     try:
         EMERGENCY_CONTROLLER.exit_emergency_mode(
             requested_by=request.requested_by,
@@ -1706,9 +1736,12 @@ def exit_emergency_mode(request: EmergencyExitRequest) -> EmergencyStatusRespons
     "/governance/emergency/action",
     tags=["Governance"],
 )
-def emergency_authorised_action(request: EmergencyActionRequest) -> Dict[str, str]:
+def emergency_authorised_action(
+    request: EmergencyActionRequest, http_request: Request
+) -> Dict[str, str]:
     """Validate that an emergency action has dual authorisation."""
 
+    require_strong_api_auth(http_request)
     try:
         EMERGENCY_CONTROLLER.request_authorised_action(
             actor=request.actor,

--- a/src/hueyos/api/routers/network.py
+++ b/src/hueyos/api/routers/network.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 router = APIRouter(tags=["Network"])
 
@@ -15,9 +15,10 @@ def network_status():
 
 
 @router.post("/network/ensure")
-def ensure_network_connectivity():
+def ensure_network_connectivity(request: Request):
     from huey.memory.PY import api as legacy_api
 
+    legacy_api.require_strong_api_auth(request)
     return legacy_api.ensure_network_connectivity()
 
 

--- a/src/hueyos/api/routers/power.py
+++ b/src/hueyos/api/routers/power.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 router = APIRouter(tags=["Power"])
 
@@ -22,9 +22,10 @@ def power_should_shutdown():
 
 
 @router.post("/power/shutdown")
-def trigger_shutdown():
+def trigger_shutdown(request: Request):
     from huey.memory.PY import api as legacy_api
 
+    legacy_api.require_strong_api_auth(request)
     return legacy_api.trigger_shutdown()
 
 

--- a/src/hueyos/api/routers/tasks.py
+++ b/src/hueyos/api/routers/tasks.py
@@ -23,6 +23,7 @@ def submit_task(request: TaskSubmissionRequest, http_request: Request) -> TaskRe
     """Submit a task for execution by Spark or Zap."""
 
     legacy_api = _legacy_api_module()
+    legacy_api.require_strong_api_auth(http_request)
     legacy_api._require_unsafe_task_submission_access(http_request)
     profile = request.resource_profile.to_profile() if request.resource_profile is not None else ResourceProfile()
     record = legacy_api.SCHEDULER.submit_task(
@@ -37,6 +38,7 @@ def submit_task(request: TaskSubmissionRequest, http_request: Request) -> TaskRe
 
 @router.get("/tasks", response_model=TaskListResponse)
 def list_tasks_endpoint(
+    http_request: Request,
     status_filter: Optional[List[TaskStatus]] = Query(
         None,
         alias="status",
@@ -46,15 +48,17 @@ def list_tasks_endpoint(
     """List known tasks with optional status filters."""
 
     legacy_api = _legacy_api_module()
+    legacy_api.require_strong_api_auth(http_request)
     records = legacy_api.SCHEDULER.list_tasks(status_filter)
     return TaskListResponse(tasks=[TaskResponse.from_record(record) for record in records])
 
 
 @router.get("/tasks/{task_id}", response_model=TaskResponse)
-def get_task(task_id: str) -> TaskResponse:
+def get_task(task_id: str, http_request: Request) -> TaskResponse:
     """Return the scheduler record for a specific task."""
 
     legacy_api = _legacy_api_module()
+    legacy_api.require_strong_api_auth(http_request)
     try:
         record = legacy_api.SCHEDULER.get_task(task_id)
     except KeyError as exc:  # pragma: no cover - defensive
@@ -63,10 +67,11 @@ def get_task(task_id: str) -> TaskResponse:
 
 
 @router.post("/tasks/{task_id}/cancel", response_model=TaskResponse, status_code=status.HTTP_202_ACCEPTED)
-def cancel_task(task_id: str) -> TaskResponse:
+def cancel_task(task_id: str, http_request: Request) -> TaskResponse:
     """Cancel a pending or running task."""
 
     legacy_api = _legacy_api_module()
+    legacy_api.require_strong_api_auth(http_request)
     try:
         record = legacy_api.SCHEDULER.cancel_task(task_id)
     except KeyError as exc:  # pragma: no cover - defensive

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -357,6 +357,9 @@ async def test_sensor_network_and_power_endpoints(monkeypatch, tmp_path):
     from hueyos.network.manager import NetworkStatus
     from hueyos.power.management import PowerEvent
 
+    monkeypatch.setenv("HUEY_API_TOKEN", "test-token")
+    auth_headers = {"Authorization": "Bearer test-token"}
+
     storage = HoneycombStorage(base_dir=tmp_path)
     registry = SensorRegistry()
     drivers.register_builtin_sensors(registry)
@@ -443,7 +446,7 @@ async def test_sensor_network_and_power_endpoints(monkeypatch, tmp_path):
         assert net_status.status_code == 200
         assert net_status.json()["active_interface"] == "eth0"
 
-        net_ensure = await client.post("/network/ensure")
+        net_ensure = await client.post("/network/ensure", headers=auth_headers)
         assert net_ensure.status_code == 200
 
         battery = await client.get("/power/battery")
@@ -454,13 +457,14 @@ async def test_sensor_network_and_power_endpoints(monkeypatch, tmp_path):
         assert should_shutdown.status_code == 200
         assert should_shutdown.json()["should_shutdown"] is False
 
-        shutdown = await client.post("/power/shutdown")
+        shutdown = await client.post("/power/shutdown", headers=auth_headers)
         assert shutdown.status_code == 200
         assert shutdown.json()["metadata"]["initiated"] is True
 
         authorised = await client.post(
             "/governance/emergency/action",
             json={"actor": "spark", "approvals": ["zap"], "action": "shed-load"},
+            headers=auth_headers,
         )
         assert authorised.status_code == 200
         assert authorised.json()["status"] == "authorised"
@@ -468,9 +472,41 @@ async def test_sensor_network_and_power_endpoints(monkeypatch, tmp_path):
         exited = await client.post(
             "/governance/emergency/exit",
             json={"requested_by": "spark", "approvals": ["zap"]},
+            headers=auth_headers,
         )
         assert exited.status_code == 200
         assert exited.json()["state"] == "normal"
+
+
+@pytest.mark.asyncio
+async def test_dangerous_endpoints_reject_unauthenticated_access(monkeypatch):
+    monkeypatch.delenv("HUEY_API_TOKEN", raising=False)
+    transport = ASGITransport(app=api_module.app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        task_submit = await client.post("/tasks", json={"command": "calibrate"})
+        network_ensure = await client.post("/network/ensure")
+        power_shutdown = await client.post("/power/shutdown")
+        emergency_enter = await client.post(
+            "/governance/emergency/enter",
+            json={"triggered_by": "spark", "reason": "test", "approvals": ["zap"]},
+        )
+        emergency_exit = await client.post(
+            "/governance/emergency/exit",
+            json={"requested_by": "spark", "approvals": ["zap"]},
+        )
+        emergency_action = await client.post(
+            "/governance/emergency/action",
+            json={"actor": "spark", "approvals": ["zap"], "action": "shed-load"},
+        )
+        memory_auto_sort = await client.post("/memory/auto-sort", json={})
+
+    assert task_submit.status_code == 401
+    assert network_ensure.status_code == 401
+    assert power_shutdown.status_code == 401
+    assert emergency_enter.status_code == 401
+    assert emergency_exit.status_code == 401
+    assert emergency_action.status_code == 401
+    assert memory_auto_sort.status_code == 401
 
 
 def test_sensor_network_power_routes_are_registered_via_focused_routers():


### PR DESCRIPTION
### Motivation

- Dangerous endpoints can modify system state (power/network/task execution/governance/memory) and must require the strongest existing authentication to prevent unauthenticated remote misuse.

### Description

- Added a dedicated guard `require_strong_api_auth(request)` that enforces a configured bearer token (`HUEY_API_TOKEN`) and validates the `Authorization: Bearer ...` header using `hmac.compare_digest` for timing-safe comparison (file: `src/huey/memory/PY/api.py`).
- Applied the strong-auth guard to mutation endpoints: `/memory/auto-sort`, governance emergency mutation endpoints (`/governance/emergency/enter`, `/governance/emergency/exit`, `/governance/emergency/action`) (file: `src/huey/memory/PY/api.py`).
- Enforced strong auth at the focused routers for task and systems mutation surfaces: task submission/listing/detail/cancel endpoints in `src/hueyos/api/routers/tasks.py` and mutating power/network endpoints `/power/shutdown` and `/network/ensure` in `src/hueyos/api/routers/power.py` and `src/hueyos/api/routers/network.py` respectively.
- Updated tests to supply auth headers where dangerous endpoints are expected to succeed and added a new test asserting unauthenticated access is rejected with `401` for dangerous endpoints (file: `tests/test_api_routes.py`).
- Left read-only and health/readiness endpoints public/local as intended (e.g. `/healthz`, `/power/battery`, `/network/status`, `/power/should-shutdown`).

### Testing

- Ran `pytest -q tests/test_api_routes.py` to exercise API route coverage; collection failed with an environment-specific ImportError because the vendored FastAPI stub in this environment lacks `JSONResponse` (`ImportError: cannot import name 'JSONResponse' from 'fastapi.responses'`), so the test run did not complete.
- Unit test changes include adding auth headers to existing integration-style route tests and a new `test_dangerous_endpoints_reject_unauthenticated_access` asserting unauthenticated requests return `401`; these tests were added but could not be fully executed here due to the collection/import error above.
- Manual verification performed in the repository by running the modified test file exposed the failure described; after resolving the import stub the updated tests should pass and demonstrate that unauthenticated access to the dangerous endpoints is rejected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a028b19bf54832faed1344795a546f7)