### PR TITLE
docs(api): add API deployment policy and default localhost bind in Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,6 +1010,42 @@ Boundary notes:
 - `huey v1-run` currently requires `--mock` unless explicit real providers are wired; this prevents overclaiming live hardware proof.
 - PyHuey stays optional cockpit/tooling (`infra/docker/pyhuey`) and is not the HueyOS/Huey Brain runtime path.
 
+### API deployment policy (safe defaults)
+
+HueyOS API is designed for **local-first operation**. Public internet exposure is **unsupported** for V1 and should be treated as unsafe unless you add your own authenticated/TLS gateway and host-level controls.
+
+- **Default bind policy:** keep API listen/bind on localhost (`127.0.0.1`).
+- **Trusted LAN exception (opt-in):** only bind beyond localhost when you intentionally expose to a trusted private network segment.
+- **Never expose directly to WAN:** do not publish `1995` directly on a public IP.
+
+Environment guidance for Docker/Compose:
+
+- `HUEY_HOST` controls the in-container API bind host. Recommended default: `127.0.0.1`.
+- `HUEY_PORT` controls the API port (default `1995`).
+- `HUEY_BIND_ADDR` controls host-side publish address in Compose. Keep `127.0.0.1` unless you intentionally need trusted-LAN access.
+
+Example (safe local default):
+
+```env
+HUEY_HOST=127.0.0.1
+HUEY_PORT=1995
+HUEY_BIND_ADDR=127.0.0.1
+```
+
+Example (trusted LAN opt-in, not internet):
+
+```env
+HUEY_HOST=0.0.0.0
+HUEY_PORT=1995
+HUEY_BIND_ADDR=0.0.0.0
+```
+
+Firewall guidance (required when non-local bind is used):
+
+- Allow inbound `tcp/1995` only from explicit trusted CIDRs (for example, `192.168.0.0/16` or a single admin host).
+- Deny all public/WAN sources to `tcp/1995`.
+- Prefer SSH tunneling or an authenticated reverse proxy with TLS over direct exposure.
+
 ### iMac ingress check
 
 From WSL Debian on the iMac:

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     env_file:
       - ${HUEY_ENV_FILE:-huey.env.example}
     environment:
-      HUEY_HOST: ${HUEY_HOST:-0.0.0.0}
+      HUEY_HOST: ${HUEY_HOST:-127.0.0.1}
       HUEY_PORT: ${HUEY_PORT:-1995}
       HUEY_CONFIG_DIR: /app/config
       HUEY_MEMORY_DIR: /app/memory
@@ -36,6 +36,7 @@ services:
       - ./memory:/app/memory
     ports:
       # Dev-safe default: publish to loopback only.
+      # WARNING: setting HUEY_BIND_ADDR=0.0.0.0 exposes the API to your LAN.
       # Remote access patterns (opt-in): SSH tunnel, authenticated reverse
       # proxy, or TLS + auth before any non-local exposure.
       - "${HUEY_BIND_ADDR:-127.0.0.1}:${HUEY_PORT:-1995}:1995"


### PR DESCRIPTION
### Motivation

- Reduce the risk of accidentally exposing the HueyOS API to the public internet by documenting a local-first deployment posture. 
- Make Docker Compose defaults safer so a developer who runs the repo locally is not surprised by an open API port. 
- Provide clear operator guidance for `HUEY_HOST`, `HUEY_PORT`, `HUEY_BIND_ADDR`, and immediate firewall recommendations for the V1 runtime.

### Description

- Added a new `### API deployment policy (safe defaults)` section to `README.md` that documents the local-first stance, explicit warning that public internet exposure is unsupported, env var guidance for `HUEY_HOST`/`HUEY_PORT`/`HUEY_BIND_ADDR`, example env blocks, and firewall guidance for `tcp/1995`.
- Changed Docker Compose API environment fallback from `0.0.0.0` to `127.0.0.1` in `infra/docker/docker-compose.yml` so containers default to binding the API to localhost.
- Added a loud warning comment in `infra/docker/docker-compose.yml` next to the `ports` mapping to call out that `HUEY_BIND_ADDR=0.0.0.0` exposes the API to the LAN.
- Files modified: `README.md` and `infra/docker/docker-compose.yml`.

### Testing

- Attempted to validate the Compose file with `docker compose -f infra/docker/docker-compose.yml config`, but the check failed due to the Docker CLI not being available in this environment (`docker: command not found`).
- No other automated tests were changed or required for this documentation and Compose-defaults update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a028d47dc08832fb0d4d6e945e25378)